### PR TITLE
Automated docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,24 @@
+name: build
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/login-action@v1
+        if: 0
+        with:
+          username: voidic
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+      - name: Build the Docker image
+        run: docker buildx build -t ghcr.io/${{ github.repository_owner }}/strfry:latest --platform linux/amd64 --push .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,4 +21,4 @@ jobs:
       - uses: docker/setup-qemu-action@v1
       - uses: docker/setup-buildx-action@v1
       - name: Build the Docker image
-        run: docker buildx build -t ghcr.io/${{ github.repository_owner }}/strfry:latest --platform linux/amd64 --push .
+        run: docker buildx build -t ghcr.io/${{ github.repository_owner }}/strfry:latest --platform linux/amd64 --platform linux/arm64 --push .


### PR DESCRIPTION
Adding docker buildx builds for amd64 & arm64 

This will push a new container image on every push from all branches, if you want to restrict it to only a single branch you can add 

```yml
on:
  push:
    branches:["master"]
```

The docker hub login step is disabled for now, you can enable this if you want the images pushed to docker hub instead of github container registry (ghcr)

You can also add tagged versions if you wanted to create stable releases by using github tags and trigger build on tag.

Preview builds on ghcr: https://github.com/v0l/strfry/pkgs/container/strfry