### PR TITLE
Patching quoting json

### DIFF
--- a/src/PluginWritePolicy.h
+++ b/src/PluginWritePolicy.h
@@ -79,9 +79,17 @@ struct PluginWritePolicy {
                 sendLookbackEvents();
             }
 
+            std::ostringstream oss;
+            oss << std::quoted(jsonStr);
+            std::string es = oss.str();
+            es.erase(0, 1);
+            es.erase(es.size() - 1);
+            tao::json::value event = tao::json::from_string(jsonStr);
+
+
             auto request = tao::json::value({
                 { "type", "new" },
-                { "event", tao::json::from_string(jsonStr) },
+                { "event", es },
                 { "receivedAt", receivedAt / 1000000 },
                 { "sourceType", eventSourceTypeToStr(sourceType) },
                 { "sourceInfo", sourceType == EventSourceType::IP4 || sourceType == EventSourceType::IP6 ? renderIP(sourceInfo) : sourceInfo },
@@ -105,7 +113,7 @@ struct PluginWritePolicy {
                     continue;
                 }
 
-                if (response.at("id").get_string() != request.at("event").at("id").get_string()) throw herr("id mismatch");
+                if (response.at("id").get_string() != event.at("id").get_string()) throw herr("id mismatch");
 
                 break;
             }


### PR DESCRIPTION
Please excuse my horrible cpp 🙈

The only times we were getting errors were when users had double quotes in their content. Specifically, an event where someone was sending a json string.

After implementing it this way, I realized I could have just quoted the content - we weren't seeing any issues with the other elements on the event. As this patch stands, we are parsing the json and then subsequently parsing the event in our plugin (which if I had just quoted content, that would have made that unnecessary). I honestly have no idea why the quoted string added an extra double quote to the beginning and the end, but my understanding of cpp functions is incredibly limited. That's why I had to strip off the first and last characters.