### PR TITLE
be friendly to people using websocat to debug

### DIFF
--- a/src/RelayIngester.cpp
+++ b/src/RelayIngester.cpp
@@ -63,6 +63,9 @@ void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
                         } else {
                             throw herr("unrecognised yesstr request");
                         }
+                    } else if (msg->payload == "\n") {
+                        // Do nothing.
+                        // This is for when someone is just sending newlines on websocat for debugging purposes.
                     } else {
                         throw herr("unparseable message");
                     }


### PR DESCRIPTION
![2023-03-14-105146_393x151_scrot](https://user-images.githubusercontent.com/1653275/225031138-0300f7fb-142d-44b0-b871-75477887a293.png)

Without this change that screen would be fill of `["NOTICE","ERROR: bad msg: unparseable message"]`.