### PR TITLE
Add nix shell build environments

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,8 @@
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
+mkShell {
+  buildInputs = [ 
+    perl perlPackages.YAML perlPackages.TemplateToolkit
+    lmdb zstd secp256k1 libb2 flatbuffers zlib openssl libuv
+  ];
+}


### PR DESCRIPTION
This enables a build environment using nix. Should work on most linux varieties but I've only tested on NixOS.