### PR TITLE
feature/freebsd-support-two: add build goal to README. optimize 'pkg install' manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A C++20 compiler is required, along with a few other common dependencies. On Deb
 
 #### FreeBSD
 
-    pkg install gcc gmake cmake git perl5 openssl lmdb flatbuffers libuv libinotify zstr secp256k1 zlib-ng p5-Regexp-Grammars p5-Module-Install-Template p5-YAML
+    pkg install -y gcc gmake cmake git perl5 openssl lmdb flatbuffers libuv libinotify zstr secp256k1 zlib-ng p5-Regexp-Grammars p5-Module-Install-Template p5-YAML
     git clone https://github.com/hoytech/strfry && cd strfry/
     git submodule update --init
     gmake setup-golpe

--- a/README.md
+++ b/README.md
@@ -29,11 +29,22 @@ Either the full set of messages in the DB can be synced, or the results of one o
 
 A C++20 compiler is required, along with a few other common dependencies. On Debian/Ubuntu use these commands:
 
+#### Linux
+
     sudo apt install -y git build-essential libyaml-perl libtemplate-perl libregexp-grammars-perl libssl-dev zlib1g-dev liblmdb-dev libflatbuffers-dev libsecp256k1-dev libzstd-dev
     git clone https://github.com/hoytech/strfry && cd strfry/
     git submodule update --init
     make setup-golpe
     make -j4
+
+#### FreeBSD
+
+    pkg install gcc gmake cmake git perl5 openssl lmdb flatbuffers libuv libinotify zstr secp256k1 zlib-ng p5-Regexp-Grammars p5-Module-Install-Template p5-YAML
+    git clone https://github.com/hoytech/strfry && cd strfry/
+    git submodule update --init
+    gmake setup-golpe
+    gmake -j4
+
 
 ### Running a relay
 


### PR DESCRIPTION
- add build goal for freebsd to README
- re-instrumented interim build instructions to test optimized pkg manifest

```
pkg install -y gcc gmake cmake git perl5 openssl lmdb flatbuffers libuv libinotify zstr secp256k1 zlib-ng p5-Regexp-Grammars p5-Module-Install-Template p5-YAML
  git clone https://github.com/cosmicpsyop/strfry.git
  cd strfry/
  git checkout feature/freebsd-support-three
  git submodule update --init
  cd golpe
  git checkout feature/freebsd-support-three
  git submodule update --init
  cd external/uWebSockets
  git checkout feature/freebsd-support-three
  cd ../../../
  gmake
```