### PR TITLE
ubuntu builds working:  use a github action to build ubuntu-latest (jammy)

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,32 @@
+name: ubuntu
+
+on: [push, pull_request]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    name: A job to build and run strfry on Ubuntu
+    steps:
+      - name: Checkout strfry
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build strfry
+        run: |
+          sudo apt update && sudo apt install -y git g++ make pkg-config libtool ca-certificates \
+          libyaml-perl libtemplate-perl libregexp-grammars-perl libssl-dev zlib1g-dev \
+          liblmdb-dev libflatbuffers-dev libsecp256k1-dev libzstd-dev
+          git submodule update --init
+          make setup-golpe
+          make -j4
+          if ! [ -f ./strfry ]; then
+             echo "Strfry build failed."
+             exit 1
+          fi
+
+      - name: Run strfry
+        run: |
+          sudo ./strfry info
+          cat /etc/os-release
+

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy as build
+FROM ubuntu:lunar as build
 ENV TZ=Europe/London
 WORKDIR /build
 RUN apt update && apt install -y --no-install-recommends \
@@ -12,11 +12,11 @@ RUN git submodule update --init
 RUN make setup-golpe
 RUN make -j4
 
-FROM ubuntu:jammy as runner
+FROM ubuntu:lunar as runner
 WORKDIR /app
 
 RUN apt update && apt install -y --no-install-recommends \
-    liblmdb0 libflatbuffers1 libsecp256k1-0 libb2-1 libzstd1 \
+    liblmdb0 libflatbuffers2 libsecp256k1-1 libb2-1 libzstd1 libssl3 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /build/strfry strfry

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:lunar as build
+FROM ubuntu:jammy as build
 ENV TZ=Europe/London
 WORKDIR /build
 RUN apt update && apt install -y --no-install-recommends \
@@ -12,11 +12,11 @@ RUN git submodule update --init
 RUN make setup-golpe
 RUN make -j4
 
-FROM ubuntu:lunar as runner
+FROM ubuntu:jammy as runner
 WORKDIR /app
 
 RUN apt update && apt install -y --no-install-recommends \
-    liblmdb0 libflatbuffers2 libsecp256k1-1 libb2-1 libzstd1 libssl3 \
+    liblmdb0 libflatbuffers1 libsecp256k1-0 libb2-1 libzstd1 \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /build/strfry strfry


### PR DESCRIPTION
built a github action to build on jammy successfully (with flatbuffers 1.12)

originally was working this as a flatbuffers compiler mismatch
https://pkgs.org/search/?q=libflatbuffers-dev
Ubuntu 20.04 LTS (Focal Fossa) flatbuffers 1.11
Ubuntu 22.04 LTS (Jammy Jellyfish flatbuffers 1.12 
Ubuntu 23.04 (Lunar Lobster)  flatbuffers  2.0.8

* flatbuffers 1.12 might be a possible min req.
* could derive a .deb package in follow on PR.
https://github.com/hoytech/strfry/issues/81
### 
tested jammy: success
fixed libs used and tested lunar: success 
https://github.com/hoytech/strfry/compare/master...cosmicpsyop:strfry:ubuntu-lunar-docker
tested focal: fail - has an issue with flatbuffers 1.11

https://github.com/hoytech/strfry/issues/69