### PR TITLE
ensure docker guest builddir is not tainted from a previous host build

### DIFF
--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -8,6 +8,7 @@ RUN apt update && apt install -y --no-install-recommends \
     libzstd-dev
 
 COPY . .
+RUN make clean
 RUN git submodule update --init
 RUN make setup-golpe
 RUN make -j4

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -8,9 +8,9 @@ RUN apt update && apt install -y --no-install-recommends \
     libzstd-dev
 
 COPY . .
-RUN make clean
 RUN git submodule update --init
 RUN make setup-golpe
+RUN make clean
 RUN make -j4
 
 FROM ubuntu:jammy as runner


### PR DESCRIPTION
was able to repro'ed dockerfile error with jammy. what was discovered was the host directory was tainted from a build that used flatbuffers 2.0.8
alternatively, one could just manually do it.
```
make clean
docker build . -t cosmicpsyop/strfry -f ubuntu.Dockerfile
docker run -v $HOME/src/strfry/strfry-db:/app/strfry-db -v /home/xsited/src/forks/strfry/strfry.conf:/app/strfry.conf  -t cosmicpsyop/strfry   
```
testing: https://github.com/hoytech/strfry/pull/86
https://github.com/hoytech/strfry/issues/69