### PR TITLE
create freebsd package framework and git action job

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,0 +1,64 @@
+# * manually applying safe.directory
+#
+# git config --global --add safe.directory /home/runner/work/strfry/strfry
+# to avoid similar errors that may not be applicable if branches or submodules are not used
+# https://stackoverflow.com/questions/72978485/git-submodule-update-failed-with-fatal-detected-dubious-ownership-in-repositor
+#
+# * release value is set to 13.2, remove to set to latest.
+#
+# * docs
+# https://github.com/vmactions/freebsd-vm/blob/main/README.md
+#
+name: freebsd
+
+on: [push, pull_request]
+
+jobs:
+  freebsd:
+    runs-on: ubuntu-latest
+    name: A job to build and run strfry in FreeBSD
+    steps:
+    - name: Checkout strfry
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Build strfry
+      uses: vmactions/freebsd-vm@v1
+      with:
+        release: 13.2
+        usesh: true
+        prepare: |
+          pkg install -y gcc gmake cmake git perl5 openssl lmdb flatbuffers libuv libinotify zstr secp256k1 zlib-ng p5-Regexp-Grammars p5-Module-Install-Template p5-YAML wget
+
+        run: |
+          # ownership workaround
+          git config --global --add safe.directory /home/runner/work/strfry/strfry
+          git config --local --name-only --get-regexp core\.sshCommand
+          git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"          
+          git submodule update --init
+          git config --global --add safe.directory /home/runner/work/strfry/strfry/golpe
+          make setup-golpe
+          gmake
+          if ! [ -f ./strfry ]; then
+             echo "Strfry build failed."
+             exit 1
+          fi
+
+          freebsd/build-pkg.sh
+
+          # backgrounding down not return
+          ./strfry info 
+          freebsd-version
+
+    - name: Verify strfry copy back
+      run: |
+          pkgfilename=`ls *.pkg`
+          echo "pkgfilename=$pkgfilename" >> $GITHUB_ENV
+
+    - name: Upload strfry
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ env.pkgfilename }}
+        path: ${{ env.pkgfilename }}
+

--- a/freebsd/MANIFEST.in
+++ b/freebsd/MANIFEST.in
@@ -1,0 +1,79 @@
+name: strfry
+version: ${VERSION}
+origin: net
+comment: Metapackage for strfry
+www: http://hoytech.com
+maintainer: Doug Hoytech <doug@hoytech.com>
+prefix: /
+desc: strfry is a relay for the nostr protocol
+flatsize:      ${DIR_SIZE}
+categories:    [net]
+${DEPS}
+licenselogic = "single";
+licenses: [GPLv3]
+users: [strfry]
+groups: [strfry]
+files: {
+  /usr/local/bin/strfry: { sum: 'sha256sum', uname: strfry, gname: strfry, perm: 0755 },
+  /etc/strfry.conf:{ sum: 'sha256sum', uname: strfry, gname: strfry, perm: 0644 };
+  /usr/local/etc/rc.d/strfry:{ sum: 'sha256sum', uname: root, gname: root, perm: 0755 };
+}
+directories: {
+  /var/lib/strfry : 'y';
+}
+scripts: {
+  pre-deinstall: <<EOD
+#!/bin/sh
+
+
+EOD
+  post-deinstall: <<EOD
+#!/bin/sh
+
+if /usr/sbin/pw  user show strfry >/dev/null 2>&1; then
+  /usr/sbin/pw user del strfry
+fi
+
+if /usr/sbin/pw group show strfry >/dev/null 2>&1; then
+  /usr/sbin/pw group del strfry
+fi
+
+EOD
+
+  post-install: <<EOD
+#!/bin/sh
+
+ln -s /etc/strfry.conf /usr/local/etc/strfry.conf >/dev/null 2>&1
+chown strfry:strfry /var/lib/strfry >/dev/null 2>&1
+if ! grep -q "strfry_enable=" /etc/rc.conf; then
+    echo 'strfry_enable="YES"' >> /etc/rc.conf
+fi
+
+
+EOD
+
+  pre-install: <<EOD
+#!/bin/sh
+
+echo "==> Creating groups."
+
+# Create strfry group if it doesn't exist
+if ! /usr/sbin/pw group show strfry >/dev/null 2>&1; then
+  echo "Creating group 'strfry' with gid '933'."
+  /usr/sbin/pw group add strfry -g 933
+else
+  echo "Using existing group 'strfry'."
+fi
+
+echo "==> Creating users"
+
+# Create strfry user if it doesn't exist
+if ! /usr/sbin/pw user show strfry >/dev/null 2>&1; then
+  echo "Creating user 'strfry' with uid '933'."
+  /usr/sbin/pw user add strfry -u 933 -g 933  -c "strfry daemon" -d /var/empty -s /usr/sbin/nologin
+else
+  echo "Using existing user 'strfry'."
+fi
+
+EOD
+}

--- a/freebsd/build-pkg.sh
+++ b/freebsd/build-pkg.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+die() 
+{
+    echo $1 && exit 1
+}
+
+which -s pkg || die "pkg(8) is not found. Aborting."
+pwd=$(pwd)
+cd "$(dirname "$0")"
+
+if [ ! -z "$1" ];
+then
+    manifest_in="$1"
+else
+    manifest_in="MANIFEST.in"
+fi
+
+if [ ! -z "$2" ];
+then
+    root_dir="$2"
+else
+    root_dir="root"
+fi
+
+mkdir -p ${root_dir}/usr/local/bin
+mkdir -p ${root_dir}/var/lib/strfry
+mkdir -p ${root_dir}/etc/
+mkdir -p ${root_dir}/usr/local/etc/rc.d
+
+cp ../strfry ${root_dir}/usr/local/bin
+cp ../strfry.conf ${root_dir}/etc/
+cp rc.strfry ${root_dir}/usr/local/etc/rc.d/strfry
+sed 's|./strfry-db/|/var/lib/strfry/|g' ${root_dir}/etc/strfry.conf > ${root_dir}/etc/strfry.conf.tmp && mv ${root_dir}/etc/strfry.conf.tmp ${root_dir}/etc/strfry.conf
+
+VERSION=$(curl -s https://api.github.com/repos/hoytech/strfry/tags | grep -o '"name": "[^"]*' | awk -F'"' 'NR==1 {print $4}')
+
+if [ -z "$VERSION" ];
+then
+    VERSION="0.9.0"
+fi
+
+DEP_LIST="openssl lmdb flatbuffers libuv libinotify zstd secp256k1 zlib-ng gcc"
+
+DIR_SIZE=$(find ${root_dir} -type f -exec stat -f %z {} + | awk 'BEGIN {s=0} {s+=$1} END {print s}')
+
+for P in ${DEP_LIST}; do
+    O=$(echo $(pkg search -e -S name -Q full $P | grep Origin | cut -d: -f2))
+    V=$(echo $(pkg search -e -S name -Q full $P | grep Version | cut -d: -f2))
+    if [ ! -z $O ] && [ ! -z $V ]; then
+	# not sure about ,1 in version string.  pkg no like.
+	V=${V%,*}
+        deps="$deps     $P: {origin: $O, version: $V},
+"
+    fi
+done
+
+DEPS="deps:{ 
+$deps}"
+export VERSION
+export DEPS
+export DIR_SIZE
+manifest=$(envsubst < MANIFEST.in)
+echo "$manifest" > +MANIFEST
+
+# Create the package
+pkg create -r ${root_dir} -m . -o ..
+
+# Verify package
+pkgfile=$(ls ../*.pkg)
+if [ -f "$pkgfile" ];
+then
+  # pkg info -R -F ${pkgfile}
+  pkg info -F ${pkgfile}
+  tar -Jtvf ${pkgfile}
+else
+  echo "Package create failed."
+  exit 1
+fi
+
+# Clean up
+rm -rf +MANIFEST +COMPACT_MANIFEST ${root_dir}
+cd "$pwd"
+exit 0

--- a/freebsd/rc.strfry
+++ b/freebsd/rc.strfry
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# PROVIDE: strfry
+### REQUIRE: DAEMON networking
+# REQUIRE: networking
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="strfry"
+rcvar="strfry_enable"
+pidfile="/var/run/${name}.pid"
+command="/usr/local/bin/strfry"
+command_args="relay &"
+#command="/usr/sbin/daemon"
+#command_args="-P ${pidfile} -r -f /usr/sbin/strfry relay"
+
+load_rc_config $name
+: ${strfry_enable:=no}
+
+run_rc_command "$1"
+pgrep ${name} > $pidfile
+
+
+


### PR DESCRIPTION
This needs to be retested once the freebsd compile adjustments have been merged.
The job does take some time since virtual machines are nested i.e. ubuntu launching kvm freebsd.
gmake -j4 or any use of nproc on freebsd seem fragile. 

While the build and run from sources functions as documented an outstanding issue is locating the package offering libstdc++ without fishing through package gcc for the pkg install use case.

This is a sample job from a functioning branch
https://github.com/cosmicpsyop/strfry/actions/runs/7205794196

Documenting working branch and how it was built locally
https://github.com/hoytech/strfry/compare/master...cosmicpsyop:strfry:feature/freebsd-support-four?expand=1#diff-6f2adbfa3a8863a041c5953f37db9c434866c90dd11b5b866c23c1c5a87f3e5cR31