### PR TITLE
deploy  strfry to vultr using terraform

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,28 @@
+# Ignore Terraform state files
+*.tfstate
+*.tfstate.*
+
+# Ignore .terraform directory
+.terraform/
+
+# Ignore override files as they are usually used to override resources locally and do not need to be checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore .tfvars files that are used to override variable values
+*.auto.tfvars
+*.auto.tfvars.json
+*.tfvars
+*.tfvars.json
+
+# Ignore crash log files
+crash.log
+
+# Ignore .terraform.lock.hcl files
+.terraform.lock.hcl
+
+# Ignore .terraform/environment files
+.terraform/environment
+

--- a/terraform/vultr/README.md
+++ b/terraform/vultr/README.md
@@ -4,7 +4,7 @@
 
  1. Add the Terraform GPG key to your server
 
-     '$ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -'
+    ' $ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -'
 
  2. Add the official Terraform repository to your APT sources
 
@@ -16,7 +16,7 @@
 
  4. Install Terraform on the server
 
-   '  $ sudo apt install terraform'
+    ' $ sudo apt install terraform'
 
 
 ## Activate Your Vultr API Key
@@ -40,6 +40,7 @@ Activate and Copy your Vultr API Key from the Vultr [Customer Portal Settings Pa
     
 2. Edit Provisioning Scripts
    Find the variables that affect the provisioning at the top of startup.freebsd.sh
+
     ```
     # change
     domain="relay.example.com"
@@ -69,7 +70,6 @@ Activate and Copy your Vultr API Key from the Vultr [Customer Portal Settings Pa
     * Linux servers use cloud-init.
     * BSD-based servers use boot scripts.
 
-
     ```
     # provision script for freebsd
     #  script_id             = vultr_startup_script.startup.id
@@ -80,18 +80,16 @@ Activate and Copy your Vultr API Key from the Vultr [Customer Portal Settings Pa
     ```
 ## Initialize Plan 
 
-
   ' terraform init '
 
 ## Test Plan 
-
 
   ' terraform plan '
   
 ## Execute Plan
 
-   ' terraform destroy  -auto-approve  '
+  ' terraform apply  -auto-approve  '
 
-## Destory Plan
+## Destroy Plan
 
-   ' terraform destroy  -auto-approve  '
+  ' terraform destroy  -auto-approve  '

--- a/terraform/vultr/README.md
+++ b/terraform/vultr/README.md
@@ -1,0 +1,97 @@
+# Deploying strfry to vultr using terraform
+
+## Install terraform
+
+ 1. Add the Terraform GPG key to your server
+
+     '$ curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -'
+
+ 2. Add the official Terraform repository to your APT sources
+
+    ' $ sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com focal main"'
+
+ 3. Update the server packages
+
+    ' $ sudo apt update'
+
+ 4. Install Terraform on the server
+
+   '  $ sudo apt install terraform'
+
+
+## Activate Your Vultr API Key
+
+Activate and Copy your Vultr API Key from the Vultr [Customer Portal Settings Page](https://my.vultr.com/settings/#settingsapi)
+
+## Edit Configuration Files
+
+1. Edit terraform.tfvars (see terraform.tfvars.example)
+   
+    ```
+    VULTR_API_KEY   = "EGJGEJIGJKSDGJKSDKSDGJKLDG444JLKG"
+    region          = "ewr"
+    plan            = "vhp-1c-2gb-amd"
+    os              = 447
+    label           = "relay.example.com"
+    hostname        = "relay"
+    script_filename = "startup.freebsd.sh"
+    ssh_key_filename= "~/.ssh/id.pub"       
+    ```
+    
+2. Edit Provisioning Scripts
+   Find the variables that affect the provisioning at the top of startup.freebsd.sh
+    ```
+    # change
+    domain="relay.example.com"
+    email="user@example.com"
+    pkgpath="http://download.example.com/downloads/"
+    pkgfile="strfry-0.9.6.pkg"
+    ```
+3. Changing Terraform Plan to Use Ubuntu
+
+    terraform.tfvars
+    ```
+    os              = 1743
+    script_filename = "startup.ubuntu.sh"
+
+    ``` 
+    startup.ubuntu.sh 
+    ```
+    # change
+    domain="relay.example.com"
+    email="user@example.com"
+    pkgpath="http://download.example.com/downloads/"
+    pkgfile="strfry_0.9.6-1_amd64.deb"
+    ```
+    main.tf
+    The way Vultr configures the server depends on the operating system.
+
+    * Linux servers use cloud-init.
+    * BSD-based servers use boot scripts.
+
+
+    ```
+    # provision script for freebsd
+    #  script_id             = vultr_startup_script.startup.id
+
+    # provision script for ubuntu
+      user_data             = "${file("${var.script_filename}")}"
+
+    ```
+## Initialize Plan 
+
+
+  ' terraform init '
+
+## Test Plan 
+
+
+  ' terraform plan '
+  
+## Execute Plan
+
+   ' terraform destroy  -auto-approve  '
+
+## Destory Plan
+
+   ' terraform destroy  -auto-approve  '

--- a/terraform/vultr/firewall.tf
+++ b/terraform/vultr/firewall.tf
@@ -1,0 +1,27 @@
+resource "vultr_firewall_group" "firewall_grp" {
+    description = "strfry Firewall"
+}
+resource "vultr_firewall_rule" "allow_http" {
+    firewall_group_id = vultr_firewall_group.firewall_grp.id
+    protocol = "tcp"
+    ip_type = "v4"
+    subnet = "0.0.0.0"
+    subnet_size = 0
+    port = "80"
+}
+resource "vultr_firewall_rule" "allow_https" {
+    firewall_group_id = vultr_firewall_group.firewall_grp.id
+    protocol = "tcp"
+    ip_type = "v4"
+    subnet = "0.0.0.0"
+    subnet_size = 0
+    port = "443"
+}
+resource "vultr_firewall_rule" "allow_ssh" {
+    firewall_group_id = vultr_firewall_group.firewall_grp.id
+    protocol = "tcp"
+    ip_type = "v4"
+    subnet = "0.0.0.0"
+    subnet_size = 0
+    port = "22"
+}

--- a/terraform/vultr/main.tf
+++ b/terraform/vultr/main.tf
@@ -48,10 +48,10 @@ resource "vultr_instance" "instance" {
   activation_email      = false
 
 # provision script for freebsd
-#  script_id             = vultr_startup_script.startup.id
+  script_id             = vultr_startup_script.startup.id
 
 # provision script for ubuntu
-  user_data             = "${file("${var.script_filename}")}"
+#  user_data             = "${file("${var.script_filename}")}"
 
 #  user_data             = <<-EOF
 #cloud-config

--- a/terraform/vultr/main.tf
+++ b/terraform/vultr/main.tf
@@ -1,0 +1,70 @@
+# Store the New Jersey location code to a variable.
+data "vultr_region" "ny" {
+  filter {
+    name   = "city"
+    values = ["New Jersey"]
+  }
+}
+
+# Store the FreeBSD 13 OS code to a variable.
+data "vultr_os" "freebsd" {
+  filter {
+    name   = "name"
+    values = ["FreeBSD 13 x64"]
+  }
+}
+
+# Store the Ubuntu 22.04 LTS OS code to a variable.
+data "vultr_os" "ubuntu" {
+  filter {
+    name   = "name"
+    values = ["Ubuntu 22.04 LTS x64"]
+  }
+}
+
+resource "vultr_ssh_key" "user" {
+  name    = "pub_key"
+  ssh_key = "${file("${var.ssh_key_filename}")}"
+}
+
+resource "vultr_startup_script" "startup" {
+    name = "strfry-deploy"
+    script = filebase64("${var.script_filename}")
+}
+
+# Deploy a Server using the High Performance, 1 Core, 2 GB RAM plan. 
+resource "vultr_instance" "instance" {
+  plan                  = var.plan
+  region                = var.region
+  os_id                 = var.os
+  label                 = var.label
+  hostname              = var.hostname
+  firewall_group_id     = vultr_firewall_group.firewall_grp.id
+  ssh_key_ids           = ["${vultr_ssh_key.user.id}"]
+  tags                  = ["strfry", "nostr"]
+  backups               = "disabled"
+  enable_ipv6           = false
+  ddos_protection       = false
+  activation_email      = false
+
+# provision script for freebsd
+#  script_id             = vultr_startup_script.startup.id
+
+# provision script for ubuntu
+  user_data             = "${file("${var.script_filename}")}"
+
+#  user_data             = <<-EOF
+#cloud-config
+# Your cloud-init configuration goes here
+#EOF
+}
+
+# Display the server IP address when complete.
+output "instance_ip" {
+  value = vultr_instance.instance.main_ip
+}
+
+output "instance_id" {
+  value = vultr_instance.instance.id
+}
+

--- a/terraform/vultr/provider.tf
+++ b/terraform/vultr/provider.tf
@@ -1,0 +1,27 @@
+terraform {
+
+   # Use the latest provider release: https://github.com/vultr/terraform-provider-vultr/releases
+   required_providers {
+     vultr = {
+       source  = "vultr/vultr"
+       version = ">= 2.15.1"
+     }
+   }
+
+   # Configure the S3 backend
+#  backend "s3" {
+#    bucket                      = "terraform-state-strfry"
+#    key                         = "terraform.tfstate"
+#    endpoint                    = "ewr1.vultrobjects.com"
+#    region                      = "us-east-1"
+#    skip_credentials_validation = true
+#  }
+}
+
+provider "vultr" {
+  api_key = var.VULTR_API_KEY
+  # Set the API rate limit
+  rate_limit  = 700
+  retry_limit = 3
+}
+

--- a/terraform/vultr/startup.freebsd.sh
+++ b/terraform/vultr/startup.freebsd.sh
@@ -1,0 +1,98 @@
+
+# change
+domain="relay.example.com"
+email="user@example.com"
+pkgpath="http://download.example.com/downloads/"
+pkgfile="strfry-0.9.6.pkg"
+
+# install depends and tools (TODO: find libstdc++ and remove gcc)
+pkg install -y wget openssl lmdb flatbuffers libuv libinotify zstd secp256k1 zlib-ng nginx curl py39-certbot-nginx gcc
+
+# setup proxy on 80 or ws://
+cat << EOF > /usr/local/etc/nginx/nginx.conf
+
+#user  nobody;
+worker_processes  1;
+
+# This default error log path is compiled-in to make sure configuration parsing
+# errors are logged somewhere, especially during unattended boot when stderr
+# isn't normally logged anywhere. This path will be touched on every nginx
+# start regardless of error log location configured here. See
+# https://trac.nginx.org/nginx/ticket/147 for more info. 
+#
+#error_log  /var/log/nginx/error.log;
+#
+
+#pid        logs/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+
+    #log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+    #                  '$status $body_bytes_sent "$http_referer" '
+    #                  '"$http_user_agent" "$http_x_forwarded_for"';
+
+    #access_log  logs/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    #keepalive_timeout  0;
+    keepalive_timeout  65;
+
+
+    # HTTPS server
+    #
+    #server {
+    #    listen       443 ssl;
+    #    server_name  localhost;
+
+    #    ssl_certificate      cert.pem;
+    #    ssl_certificate_key  cert.key;
+
+    #    ssl_session_cache    shared:SSL:1m;
+    #    ssl_session_timeout  5m;
+
+    #    ssl_ciphers  HIGH:!aNULL:!MD5;
+    #    ssl_prefer_server_ciphers  on;
+
+    #    location / {
+    #        root   html;
+    #        index  index.html index.htm;
+    #    }
+    #}
+
+    server{
+        server_name $domain;
+        location / {
+            proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+            proxy_set_header Host \$host;
+            proxy_pass http://127.0.0.1:7777;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade \$http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+    }
+}
+EOF
+# enable nginx
+if ! grep -q "nginx_enable=" /etc/rc.conf; then
+    echo 'nginx_enable="YES"' >> /etc/rc.conf
+fi
+
+# fetch and install strfry (pkg enables by default)
+cd /tmp
+/usr/local/bin/wget $pkgpath/$pkgfile
+pkg add ./$pkgfile
+
+service strfry start
+service nginx start
+
+# requires dns configured for domain
+# certbot register --agree-tos --email $email --non-interactive
+# certbot --nginx  -d $domain

--- a/terraform/vultr/startup.ubuntu.sh
+++ b/terraform/vultr/startup.ubuntu.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# change
+domain="relay.example.com"
+email="user@example.com"
+pkgpath="http://download.example.com/downloads/"
+pkgfile="strfry_0.9.6-1_amd64.deb"
+
+# install depends and tools 
+apt update && apt install -y --no-install-recommends \
+    wget liblmdb0 libflatbuffers1 libsecp256k1-0 libb2-1 libzstd1 \
+    nginx certbot python3-certbot-nginx
+
+# setup proxy on 80 or ws://
+cat << EOF > /etc/nginx/sites-available/default
+server{
+    server_name $domain;
+    location / {
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header Host \$host;
+        proxy_pass http://127.0.0.1:7777;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade \$http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+}
+EOF
+
+cd /tmp
+wget $pkgpath/$pkgfile
+dpkg -i ./$pkgfile
+systemctl restart nginx
+
+# requires dns configured for domain
+# certbot register --agree-tos --email $email --non-interactive
+# certbot --nginx -d $domain

--- a/terraform/vultr/terraform.tfvars.example
+++ b/terraform/vultr/terraform.tfvars.example
@@ -1,0 +1,16 @@
+VULTR_API_KEY   = "EGJGEJIGJKSDGJKSDKSDGJKLDG444JLKG"
+region          = "ewr"
+plan            = "vhp-1c-2gb-amd"
+# $12 plans
+# Plan           = "vc2-1c-1gb"
+# plan           = "vhf-2c-4gb"
+# plan           = "vhp-1c-2gb-amd"
+os              = 447
+# os             = 1743 ubuntu 22.04
+# os             = 2136 debian 12
+# os             = 447  freebsd 13
+label           = "relay.example.com"
+hostname        = "relay"
+script_filename = "startup.freebsd.sh"
+# script_filename = "startup.ubuntu.sh"
+ssh_key_filename= "~/.ssh/id.pub"

--- a/terraform/vultr/variable.tf
+++ b/terraform/vultr/variable.tf
@@ -1,0 +1,39 @@
+variable "VULTR_API_KEY" {
+    description   = "Vultr API token"
+    type          = string
+}
+
+variable "os" {
+    description   = "OS"
+    type          = string
+}
+
+variable "plan" {
+    description   = "Plan"
+    type          = string
+}
+
+variable "label" {
+    description   = "Server Name Labeling"
+    type          = string
+}
+
+variable "region" {
+    description   = "Region"
+    type          = string
+}
+
+variable "hostname" {
+    description   = "Resource Hostname"
+    type          = string
+}
+
+variable "script_filename" {
+    description   = "Provisioning Script"
+    type          = string
+}
+
+variable "ssh_key_filename" {
+    description   = "SSH Key File"
+    type          = string
+}


### PR DESCRIPTION
Using terraform automate deployment of strfry fronted by nginx on port 80.

This works for both freebsd and ubuntu using the docs/DEPLOYMENT.md guide.  The default is freebsd

It does not complete the provisioning of DNS which would require using vultrs API and primary DNS service in order to successfully allow certbot to obtain and configure a cert for nginx.

The README.md explains some differences between freebsd and ubuntu and a couple caveats.  In particular,  using the github action upload to download the package onto the vm does not work without user authentication with github.  Therefore a download server is require to host the raw packages or ideally the packages are pushed to a public repo.
