### PR TITLE
Ignore unrecognized filters

### DIFF
--- a/src/filters.h
+++ b/src/filters.h
@@ -154,8 +154,8 @@ struct NostrFilter {
                 until = v.get_unsigned();
             } else if (k == "limit") {
                 limit = v.get_unsigned();
-            } else {
-                throw herr("unrecognised filter item");
+            } else if (k == "search") {
+                throw herr("search is not supported");
             }
         }
 


### PR DESCRIPTION
NIP-01 is pretty stable, and custom filters should be able to degrade gracefully. Known unsupported filters like `search` can be errored, but clients should rely on `supported_nips` to know whether a relay will support the filter before sending it. It's better to just ignore unrecognized keys. It won't have catastrophic consequences and will allow custom filters to gracefully degrade.