### PR TITLE
Add NIP-11 limitations

### DIFF
--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -56,6 +56,11 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
                 { "supported_nips", supportedNips },
                 { "software", "git+https://github.com/hoytech/strfry.git" },
                 { "version", APP_GIT_VERSION },
+                { "limitation", tao::json::value({
+                    { "max_message_length", cfg().relay__maxWebsocketPayloadSize },
+                    { "max_subscriptions", cfg().relay__maxSubsPerConnection },
+                    { "max_limit", cfg().relay__maxFilterLimit },
+                }) },
             });
 
             if (cfg().relay__info__name.size()) nip11["name"] = cfg().relay__info__name;


### PR DESCRIPTION
Extends NIP-11 support with the [limitation field](https://github.com/nostr-protocol/nips/blob/master/11.md#server-limitations), mapped to strfry config for all the values that made sense to match. Especially `max_subscriptions` which is the one I care about most.

![image](https://github.com/hoytech/strfry/assets/3639540/6cb3796b-76b7-471a-8559-b1ec98386e01)
