### PR TITLE
NIP-114: ids_only filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ This will download all missing events from the remote relay and insert them into
 
 Instead of a "full DB" sync, you can also sync the result of a nostr filter (or multiple filters, use a JSON array of them):
 
-    ./strfry sync wss://relay.example.com '{"authors":["003b"]}'
+    ./strfry sync wss://relay.example.com --filter '{"authors":["003b"]}'
 
 Warning: Syncing can consume a lot of memory and bandwidth if the DBs are highly divergent (for example if your local DB is empty and your filter matches many events).
 

--- a/src/apps/relay/RelayReqMonitor.cpp
+++ b/src/apps/relay/RelayReqMonitor.cpp
@@ -32,7 +32,12 @@ void RelayServer::runReqMonitor(ThreadPool<MsgReqMonitor>::Thread &thr) {
 
                 env.foreach_Event(txn, [&](auto &ev){
                     if (msg->sub.filterGroup.doesMatch(ev.flat_nested())) {
-                        sendEvent(connId, msg->sub.subId, getEventJson(txn, decomp, ev.primaryKeyId));
+                        if (msg->sub.filterGroup.ids_only()) {
+                            auto id = to_hex(sv(ev.flat_nested()->id()));
+                            sendHave(connId, msg->sub.subId, id);
+                        } else {
+                            sendEvent(connId, msg->sub.subId, getEventJson(txn, decomp, ev.primaryKeyId));
+                        }
                     }
 
                     return true;

--- a/src/apps/relay/RelayServer.h
+++ b/src/apps/relay/RelayServer.h
@@ -211,6 +211,21 @@ struct RelayServer {
         sendToConn(connId, std::move(reply));
     }
 
+    void sendHave(uint64_t connId, const SubId &subId, const std::string_view eventId) {
+        auto subIdSv = subId.sv();
+
+        std::string reply;
+        reply.reserve(14 + subIdSv.size() + eventId.size());
+
+        reply += "[\"HAVE\",\"";
+        reply += subIdSv;
+        reply += "\",\"";
+        reply += eventId;
+        reply += "\"]";
+
+        sendToConn(connId, std::move(reply));
+    }
+
     void sendEventToBatch(RecipientList &&list, std::string &&evJson) {
         tpWebsocket.dispatch(0, MsgWebsocket{MsgWebsocket::SendEventToBatch{std::move(list), std::move(evJson)}});
         hubTrigger->send();

--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -48,7 +48,7 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
     tempBuf.reserve(cfg().events__maxEventSize + MAX_SUBID_SIZE + 100);
 
 
-    tao::json::value supportedNips = tao::json::value::array({ 1, 2, 4, 9, 11, 12, 16, 20, 22, 28, 33, 40 });
+    tao::json::value supportedNips = tao::json::value::array({ 1, 2, 4, 9, 11, 12, 16, 20, 22, 28, 33, 40, 114 });
 
     auto getServerInfoHttpResponse = [&supportedNips, ver = uint64_t(0), rendered = std::string("")]() mutable {
         if (ver != cfg().version()) {

--- a/src/filters.h
+++ b/src/filters.h
@@ -116,6 +116,7 @@ struct NostrFilter {
     uint64_t limit = MAX_U64;
     bool neverMatch = false;
     bool indexOnlyScans = false;
+    bool idsOnly = false;
 
     explicit NostrFilter(const tao::json::value &filterObj, uint64_t maxFilterLimit) {
         uint64_t numMajorFields = 0;
@@ -154,6 +155,8 @@ struct NostrFilter {
                 until = v.get_unsigned();
             } else if (k == "limit") {
                 limit = v.get_unsigned();
+            } else if (k == "ids_only") {
+                idsOnly = v.get_boolean();
             } else {
                 throw herr("unrecognised filter item");
             }
@@ -243,6 +246,14 @@ struct NostrFilterGroup {
     bool doesMatch(const NostrIndex::Event *ev) const {
         for (const auto &f : filters) {
             if (f.doesMatch(ev)) return true;
+        }
+
+        return false;
+    }
+
+    bool ids_only() const {
+        for (const auto &f : filters) {
+            if (f.idsOnly) return true;
         }
 
         return false;


### PR DESCRIPTION
When a subscription has a filter with `ids_only: true`, the relay responds with `[HAVE, subId, eventID]` messages. The client can then request the full event from only one relay instead of receiving it from all subscribed relays. If the event is already in a local database, the full event request can be skipped altogether.

I have not implemented this for the `stream` command yet, but this could save a lot of bandwidth if you're connecting to many other relays and subscribing to everything.