### PR TITLE
Set bindHost to 0.0.0.0 if is docker and bind is config default

### DIFF
--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -3,8 +3,6 @@
 #include "StrfryTemplates.h"
 #include "app_git_version.h"
 
-
-
 static std::string preGenerateHttpResponse(const std::string &contentType, const std::string &content) {
     std::string output = "HTTP/1.1 200 OK\r\n";
     output += std::string("Content-Type: ") + contentType + "\r\n";
@@ -289,11 +287,15 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
         (*r)();
     });
 
-
-
     int port = cfg().relay__port;
 
-    std::string bindHost = cfg().relay__bind;
+    std::string bindHost;
+    
+    if (std::filesystem::exists("/.dockerenv") || cfg().relay__bind == "127.0.0.1") {
+        bindHost = "0.0.0.0";
+    } else {
+        bindHost = cfg().relay__bind;
+    }
 
     if (!hub.listen(bindHost.c_str(), port, nullptr, uS::REUSE_PORT, hubGroup)) throw herr("unable to listen on port ", port);
 

--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -291,7 +291,7 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
 
     std::string bindHost;
     
-    if (std::filesystem::exists("/.dockerenv") || cfg().relay__bind == "127.0.0.1") {
+    if (std::filesystem::exists("/.dockerenv") && cfg().relay__bind == "127.0.0.1") {
         bindHost = "0.0.0.0";
     } else {
         bindHost = cfg().relay__bind;


### PR DESCRIPTION
Small change that can save people time. 

For example, #53 

_untested PR fueled by catharsis_ 

Probably needs a more complete implementation to detect different containers and act appropriately, for example while docker detection is `/.dockerenv`, podman detection is `/run/.containerenv`. 

Also, should probably just throw a warning instead of overriding the config. 