### PR TITLE
filters: match >=, <= for since, until

### DIFF
--- a/src/filters.h
+++ b/src/filters.h
@@ -167,8 +167,8 @@ struct NostrFilter {
     }
 
     bool doesMatchTimes(uint64_t created) const {
-        if (created < since) return false;
-        if (created > until) return false;
+        if (created <= since) return false;
+        if (created >= until) return false;
         return true;
     }
 


### PR DESCRIPTION
NIP-01:

> The `since` and `until` properties can be used to specify the time range of events returned in the subscription. If a filter includes the `since` property, events with `created_at` greater than or equal to `since` are considered to match the filter. The `until` property is similar except that `created_at` must be less than or equal to `until`. In short, an event matches a filter if `since <= created_at <= until` holds.

I am not sure if this also needs to be changed somewhere else when indexing.