### PR TITLE
Add `make clean` to docker images after local copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN \
   && rm -rf /var/cache/apk/* \
   && git submodule update --init \
   && make setup-golpe \
+  && make clean \
   && make -j4
 
 FROM alpine:3.18.3

--- a/arch.Dockerfile
+++ b/arch.Dockerfile
@@ -23,6 +23,8 @@ RUN git submodule update --init
 # build golpe
 RUN make setup-golpe 
 
+RUN make clean
+
 # build strfry
 RUN make
 


### PR DESCRIPTION
Similarly to https://github.com/paplorinc/strfry/blob/233c50c88be68c08de93211300bd80cbc89523ae/ubuntu.Dockerfile#L12, to make sure that the state of the local build doesn't affect the container (tried building it on a mac and naturally it had completely different build artefacts).