### PR TITLE
Update docker image for better caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A C++20 compiler is required, along with a few other common dependencies. On Deb
     git clone https://github.com/hoytech/strfry && cd strfry/
     git submodule update --init
     make setup-golpe
-    make -j4
+    make -j$(nproc)
 
 #### FreeBSD
 
@@ -43,7 +43,7 @@ A C++20 compiler is required, along with a few other common dependencies. On Deb
     git clone https://github.com/hoytech/strfry && cd strfry/
     git submodule update --init
     gmake setup-golpe
-    gmake -j4
+    gmake -j$(sysctl -n hw.ncpu)
 
 
 ### Running a relay

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy as build
+FROM ubuntu:jammy AS build
 ENV TZ=Europe/London
 WORKDIR /build
 RUN apt update && apt install -y --no-install-recommends \
@@ -12,7 +12,7 @@ RUN make setup-golpe
 RUN make clean
 RUN make -j4
 
-FROM ubuntu:jammy as runner
+FROM ubuntu:jammy AS runner
 WORKDIR /app
 
 RUN apt update && apt install -y --no-install-recommends \


### PR DESCRIPTION
Put the creating of the runtime and compile images before the `copy . .` so that they're cached as stable layers, to make sure local changes don't rebuild them.

The build image is now built on top of the runtime image, speeding up build time (and making sure the copied files are actually run on the exact same platform).

Also added `make clean`, fixed in https://github.com/hoytech/golpe/pull/3/files.
These fix the build issue mentioned in https://github.com/hoytech/strfry/issues/107