### PR TITLE
Add timeout config for router.

### DIFF
--- a/src/apps/mesh/cmd_router.cpp
+++ b/src/apps/mesh/cmd_router.cpp
@@ -218,7 +218,7 @@ struct Router {
     };
 
     std::string routerConfigFile;
-    uint64_t connectionTimeoutUs = 5'000'000;
+    uint64_t connectionTimeoutUs = 20'000'000;
 
     WriterPipeline writer;
     Decompressor decomp;
@@ -292,6 +292,19 @@ struct Router {
 
     void reconcileConfig() {
         LI << "Loading router config file: " << routerConfigFile;
+
+	try {
+            auto routerConfig = loadRawTaoConfig(routerConfigFile);
+
+	    if (routerConfig.find("timeout")) {
+	        connectionTimeoutUs = stoi(routerConfig.at("timeout").get_string()) * 1'000'000;
+	        LI << "Using configured timeout (seconds): " << (connectionTimeoutUs / 1'000'000);
+	    } else {
+	        LI << "Using default timeout (seconds): " << connectionTimeoutUs / 1'000'000;
+	    }
+	} catch (std::exception &e) {
+            LE << "Failed to parse router timeout in config: " << e.what();
+	}
 
         try {
             auto routerConfig = loadRawTaoConfig(routerConfigFile);


### PR DESCRIPTION
A few changes to work with configuration files created by [strfry-tools](https://github.com/braydonf/strfry-tools), this can include hundreds of streams based upon the `kind 3` follows/contacts of an npub and `kind 10002` relay list metadata for each contact.

Related: https://github.com/hoytech/strfry/issues/45#issuecomment-2375257005