### PR TITLE
fix: Clamp Event strings

### DIFF
--- a/src/WriterPipeline.h
+++ b/src/WriterPipeline.h
@@ -72,7 +72,10 @@ struct WriterPipeline {
                     try {
                         parseAndVerifyEvent(m.eventJson, secpCtx, verifyMsg, verifyTime, packedStr, jsonStr);
                     } catch (std::exception &e) {
-                        if (verboseReject) LW << "Rejected event: " << m.eventJson.get_string().substr(0,200) << " reason: " << e.what();
+                        if (verboseReject) {
+                            jsonStr = tao::json::to_string(m.eventJson).substr(0,200);
+                            LW << "Rejected event: " << jsonStr << " reason: " << e.what();
+                        }
                         numLive--;
                         totalRejected++;
                         continue;

--- a/src/WriterPipeline.h
+++ b/src/WriterPipeline.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include<string.h>
 #include <hoytech/protected_queue.h>
 
 #include "golpe.h"
@@ -71,7 +72,7 @@ struct WriterPipeline {
                     try {
                         parseAndVerifyEvent(m.eventJson, secpCtx, verifyMsg, verifyTime, packedStr, jsonStr);
                     } catch (std::exception &e) {
-                        if (verboseReject) LW << "Rejected event: " << m.eventJson << " reason: " << e.what();
+                        if (verboseReject) LW << "Rejected event: " << m.eventJson.get_string().substr(0,200) << " reason: " << e.what();
                         numLive--;
                         totalRejected++;
                         continue;


### PR DESCRIPTION
When an event is rejected because it's too large, the entire event is printed to the log.

This floods the log and makes it totally unreadable. So this change clamps it to 200 chars to prevent this.