### PR TITLE
config: add maxReqFilterSize

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,6 @@
 with pkgs;
 mkShell {
   buildInputs = [ 
-    perl lmdb zstd secp256k1 flatbuffers zlib openssl libuv
+    perl lmdb zstd secp256k1 flatbuffers_23 zlib openssl libuv
   ];
 }

--- a/src/apps/relay/RelayIngester.cpp
+++ b/src/apps/relay/RelayIngester.cpp
@@ -124,7 +124,7 @@ void RelayServer::ingesterProcessEvent(lmdb::txn &txn, uint64_t connId, std::str
 
 void RelayServer::ingesterProcessReq(lmdb::txn &txn, uint64_t connId, const tao::json::value &arr) {
     if (arr.get_array().size() < 2 + 1) throw herr("arr too small");
-    if (arr.get_array().size() > 2 + 20) throw herr("arr too big");
+    if (arr.get_array().size() > 2 + cfg().relay__maxReqFilterSize) throw herr("arr too big");
 
     Subscription sub(connId, jsonGetString(arr[1], "REQ subscription id was not a string"), NostrFilterGroup(arr));
 

--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -38,6 +38,10 @@ config:
     desc: "Maximum accepted incoming websocket frame size (should be larger than max event)"
     default: 131072
     noReload: true
+  - name: relay__maxReqFilterSize
+    desc: "Maximum number of filters allowed in a REQ"
+    default: 20
+    noReload: true
   - name: relay__autoPingSeconds
     desc: "Websocket-level PING message frequency (should be less than any reverse proxy idle timeouts)"
     default: 55

--- a/strfry.conf
+++ b/strfry.conf
@@ -75,6 +75,9 @@ relay {
     # Maximum accepted incoming websocket frame size (should be larger than max event) (restart required)
     maxWebsocketPayloadSize = 131072
 
+    # Maximum number of filters allowed in a REQ
+    maxReqFilterSize = 20
+
     # Websocket-level PING message frequency (should be less than any reverse proxy idle timeouts) (restart required)
     autoPingSeconds = 55
 


### PR DESCRIPTION
Add a configurable option for expanding the number of allowed filters in REQ.

The motivation here is to support queries of this nature:

```
["REQ", "last-note-from-each-user",
{ "authors": [ "a" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "b" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "c" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "d" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "e" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "f" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "g" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "h" ], "kinds": [ 1 ], "limit": 1 },
{ "authors": [ "i" ], "kinds": [ 1 ], "limit": 1 }
...
* 1000
]
```
