### PR TITLE
Reminder of 32-byte HEX format for the NIP-11 Admin setting in strfry.conf

### DIFF
--- a/strfry.conf
+++ b/strfry.conf
@@ -59,7 +59,7 @@ relay {
         # NIP-11: Detailed information about relay, free-form
         description = "This is a strfry instance."
 
-        # NIP-11: Administrative nostr pubkey, for contact purposes
+        # NIP-11: Administrative nostr pubkey (in 32-byte HEX format), for contact purposes
         pubkey = ""
 
         # NIP-11: Alternative administrative contact (email, website, etc)


### PR DESCRIPTION
Added reminder to use 32-byte HEX format for the NIP-11 Administrator pub key in the default strfry.conf file. If you look at https://next.nostr.watch you'll see that a lot of the sites running strfry are showing up in the list of sites generated when using the "relays with nip-11 errors" filter.  This minor change may help new admins avoid this error.