### PR TITLE
Add Prometheus metrics

### DIFF
--- a/src/PrometheusMetrics.h
+++ b/src/PrometheusMetrics.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <atomic>
+#include <string>
+#include <sstream>
+#include <map>
+#include <mutex>
+#include <shared_mutex>
+
+// Simple thread-safe Prometheus metrics implementation
+// Supports counters with labels
+
+class PrometheusMetrics {
+public:
+    // Counter for tracking cumulative values
+    class Counter {
+    private:
+        std::atomic<uint64_t> value{0};
+        
+    public:
+        void inc(uint64_t n = 1) {
+            value.fetch_add(n, std::memory_order_relaxed);
+        }
+        
+        uint64_t get() const {
+            return value.load(std::memory_order_relaxed);
+        }
+    };
+
+    // Labeled counter - allows multiple counters with different label values
+    class LabeledCounter {
+    private:
+        mutable std::shared_mutex mutex;
+        std::map<std::string, Counter> counters;
+        
+    public:
+        void inc(const std::string& label, uint64_t n = 1) {
+            // Try read lock first for common case
+            {
+                std::shared_lock<std::shared_mutex> lock(mutex);
+                auto it = counters.find(label);
+                if (it != counters.end()) {
+                    it->second.inc(n);
+                    return;
+                }
+            }
+            
+            // Need to create new counter
+            std::unique_lock<std::shared_mutex> lock(mutex);
+            counters[label].inc(n);
+        }
+        
+        std::map<std::string, uint64_t> getAll() const {
+            std::shared_lock<std::shared_mutex> lock(mutex);
+            std::map<std::string, uint64_t> result;
+            for (const auto& [label, counter] : counters) {
+                result[label] = counter.get();
+            }
+            return result;
+        }
+    };
+
+    // Singleton instance
+    static PrometheusMetrics& getInstance() {
+        static PrometheusMetrics instance;
+        return instance;
+    }
+
+    // Nostr client message counters (messages FROM clients TO relay)
+    LabeledCounter nostrClientMessages;
+    
+    // Nostr relay message counters (messages FROM relay TO clients)
+    LabeledCounter nostrRelayMessages;
+    
+    // Nostr event counters (by kind)
+    LabeledCounter nostrEventsByKind;
+
+    // Generate Prometheus text format output
+    std::string render() const {
+        std::ostringstream out;
+        
+        // Client messages
+        out << "# HELP nostr_client_messages_total Total number of Nostr client messages by verb\n";
+        out << "# TYPE nostr_client_messages_total counter\n";
+        auto clientMsgs = nostrClientMessages.getAll();
+        for (const auto& [verb, count] : clientMsgs) {
+            out << "nostr_client_messages_total{verb=\"" << verb << "\"} " << count << "\n";
+        }
+        
+        // Relay messages
+        out << "# HELP nostr_relay_messages_total Total number of Nostr relay messages by verb\n";
+        out << "# TYPE nostr_relay_messages_total counter\n";
+        auto relayMsgs = nostrRelayMessages.getAll();
+        for (const auto& [verb, count] : relayMsgs) {
+            out << "nostr_relay_messages_total{verb=\"" << verb << "\"} " << count << "\n";
+        }
+        
+        // Events by kind
+        out << "# HELP nostr_events_total Total number of Nostr events by kind\n";
+        out << "# TYPE nostr_events_total counter\n";
+        auto events = nostrEventsByKind.getAll();
+        for (const auto& [kind, count] : events) {
+            out << "nostr_events_total{kind=\"" << kind << "\"} " << count << "\n";
+        }
+        
+        return out.str();
+    }
+
+private:
+    PrometheusMetrics() = default;
+    PrometheusMetrics(const PrometheusMetrics&) = delete;
+    PrometheusMetrics& operator=(const PrometheusMetrics&) = delete;
+};
+
+// Convenience macros for incrementing metrics
+#define PROM_INC_CLIENT_MSG(verb) PrometheusMetrics::getInstance().nostrClientMessages.inc(verb)
+#define PROM_INC_RELAY_MSG(verb) PrometheusMetrics::getInstance().nostrRelayMessages.inc(verb)
+#define PROM_INC_EVENT_KIND(kind) PrometheusMetrics::getInstance().nostrEventsByKind.inc(kind)

--- a/src/apps/relay/RelayNegentropy.cpp
+++ b/src/apps/relay/RelayNegentropy.cpp
@@ -101,6 +101,7 @@ void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
         } catch (std::exception &e) {
             LI << "[" << connId << "] Error parsing negentropy message: " << e.what();
 
+            PROM_INC_RELAY_MSG("NEG-ERR");
             sendToConn(connId, tao::json::to_string(tao::json::value::array({
                 "NEG-ERR",
                 subId.str(),
@@ -111,6 +112,7 @@ void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
             return;
         }
 
+        PROM_INC_RELAY_MSG("NEG-MSG");
         sendToConn(connId, tao::json::to_string(tao::json::value::array({
             "NEG-MSG",
             subId.str(),
@@ -146,6 +148,7 @@ void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
         if (view->levIds.size() > cfg().relay__negentropy__maxSyncEvents) {
             LI << "[" << sub.connId << "] Negentropy query size exceeded " << cfg().relay__negentropy__maxSyncEvents;
 
+            PROM_INC_RELAY_MSG("NEG-ERR");
             sendToConn(sub.connId, tao::json::to_string(tao::json::value::array({
                 "NEG-ERR",
                 sub.subId.str(),
@@ -225,6 +228,7 @@ void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
             } else if (auto msg = std::get_if<MsgNegentropy::NegMsg>(&newMsg.msg)) {
                 auto *userView = views.findView(msg->connId, msg->subId);
                 if (!userView) {
+                    PROM_INC_RELAY_MSG("NEG-ERR");
                     sendToConn(msg->connId, tao::json::to_string(tao::json::value::array({
                         "NEG-ERR",
                         msg->subId.str(),

--- a/src/apps/relay/RelayReqWorker.cpp
+++ b/src/apps/relay/RelayReqWorker.cpp
@@ -11,6 +11,7 @@ void RelayServer::runReqWorker(ThreadPool<MsgReqWorker>::Thread &thr) {
     };
 
     queries.onComplete = [&](lmdb::txn &, Subscription &sub){
+        PROM_INC_RELAY_MSG("EOSE");
         sendToConn(sub.connId, tao::json::to_string(tao::json::value::array({ "EOSE", sub.subId.str() })));
         tpReqMonitor.dispatch(sub.connId, MsgReqMonitor{MsgReqMonitor::NewSub{std::move(sub)}});
     };

--- a/src/apps/relay/RelayServer.h
+++ b/src/apps/relay/RelayServer.h
@@ -18,6 +18,7 @@
 #include "filters.h"
 #include "jsonParseUtils.h"
 #include "Decompressor.h"
+#include "PrometheusMetrics.h"
 
 
 
@@ -197,6 +198,7 @@ struct RelayServer {
     }
 
     void sendEvent(uint64_t connId, const SubId &subId, std::string_view evJson) {
+        PROM_INC_RELAY_MSG("EVENT");
         auto subIdSv = subId.sv();
 
         std::string reply;
@@ -217,6 +219,7 @@ struct RelayServer {
     }
 
     void sendNoticeError(uint64_t connId, std::string &&payload) {
+        PROM_INC_RELAY_MSG("NOTICE");
         LI << "sending error to [" << connId << "]: " << payload;
         auto reply = tao::json::value::array({ "NOTICE", std::string("ERROR: ") + payload });
         tpWebsocket.dispatch(0, MsgWebsocket{MsgWebsocket::Send{connId, std::move(tao::json::to_string(reply))}});
@@ -224,6 +227,7 @@ struct RelayServer {
     }
 
     void sendOKResponse(uint64_t connId, std::string_view eventIdHex, bool written, std::string_view message) {
+        PROM_INC_RELAY_MSG("OK");
         auto reply = tao::json::value::array({ "OK", eventIdHex, written, message });
         tpWebsocket.dispatch(0, MsgWebsocket{MsgWebsocket::Send{connId, std::move(tao::json::to_string(reply))}});
         hubTrigger->send();


### PR DESCRIPTION
Add basic Prometheus metrics for client messages (by verb), relay messages (by verb), and events (by kind)

<img width="1898" height="828" alt="image" src="https://github.com/user-attachments/assets/7ed1e544-8932-48bb-9599-a78566fe5a6b" />
