### PR TITLE
Feature: Add NIP-91

### DIFF
--- a/src/ActiveMonitors.h
+++ b/src/ActiveMonitors.h
@@ -176,14 +176,19 @@ struct ActiveMonitors : NonCopyable {
                     auto res = allAuthors.try_emplace(Bytes32(f.authors->at(i)));
                     res.first->second.try_emplace(&f, MonitorItem{m, currEventId});
                 }
-            } else if (f.tags.size()) {
-                for (const auto &[tagName, filterSet] : f.tags) {
-                    for (size_t i = 0; i < filterSet.size(); i++) {
-                        auto &tagSpec = getTagSpec(tagName, filterSet.at(i));
-                        auto res = allTags.try_emplace(tagSpec);
-                        res.first->second.try_emplace(&f, MonitorItem{m, currEventId});
+            } else if (f.tags.size() || f.tagsAnd.size()) {
+                auto addTags = [&](const auto &map){
+                    for (const auto &[tagName, filterSet] : map) {
+                        for (size_t i = 0; i < filterSet.size(); i++) {
+                            auto &tagSpec = getTagSpec(tagName, filterSet.at(i));
+                            auto res = allTags.try_emplace(tagSpec);
+                            res.first->second.try_emplace(&f, MonitorItem{m, currEventId});
+                        }
                     }
-                }
+                };
+
+                addTags(f.tags);
+                addTags(f.tagsAnd);
             } else if (f.kinds) {
                 for (size_t i = 0; i < f.kinds->size(); i++) {
                     auto res = allKinds.try_emplace(f.kinds->at(i));
@@ -211,15 +216,20 @@ struct ActiveMonitors : NonCopyable {
                     monSet.erase(&f);
                     if (monSet.empty()) allAuthors.erase(author);
                 }
-            } else if (f.tags.size()) {
-                for (const auto &[tagName, filterSet] : f.tags) {
-                    for (size_t i = 0; i < filterSet.size(); i++) {
-                        auto &tagSpec = getTagSpec(tagName, filterSet.at(i));
-                        auto &monSet = allTags.at(tagSpec);
-                        monSet.erase(&f);
-                        if (monSet.empty()) allTags.erase(tagSpec);
+            } else if (f.tags.size() || f.tagsAnd.size()) {
+                auto removeTags = [&](const auto &map){
+                    for (const auto &[tagName, filterSet] : map) {
+                        for (size_t i = 0; i < filterSet.size(); i++) {
+                            auto &tagSpec = getTagSpec(tagName, filterSet.at(i));
+                            auto &monSet = allTags.at(tagSpec);
+                            monSet.erase(&f);
+                            if (monSet.empty()) allTags.erase(tagSpec);
+                        }
                     }
-                }
+                };
+
+                removeTags(f.tags);
+                removeTags(f.tagsAnd);
             } else if (f.kinds) {
                 for (size_t i = 0; i < f.kinds->size(); i++) {
                     uint64_t kind = f.kinds->at(i);

--- a/src/DBQuery.h
+++ b/src/DBQuery.h
@@ -120,22 +120,30 @@ struct DBScan : NonCopyable {
                     }
                 );
             }
-        } else if (f.tags.size()) {
+        } else if (f.tags.size() || f.tagsAnd.size()) {
             indexDbi = env.dbi_Event__tag;
             desc = "Tag";
 
             char tagName = '\0';
+            bool fromAnd = false;
             {
                 uint64_t numTags = MAX_U64;
-                for (const auto &[tn, filterSet] : f.tags) {
-                    if (filterSet.size() < numTags) {
-                        numTags = filterSet.size();
-                        tagName = tn;
+                auto consider = [&](const auto &map, bool isAnd){
+                    for (const auto &[tn, filterSet] : map) {
+                        if (filterSet.size() < numTags) {
+                            numTags = filterSet.size();
+                            tagName = tn;
+                            fromAnd = isAnd;
+                        }
                     }
-                }
+                };
+
+                consider(f.tags, false);
+                consider(f.tagsAnd, true);
             }
 
-            const auto &filterSet = f.tags.at(tagName);
+            const auto &filterSet = fromAnd ? f.tagsAnd.at(tagName) : f.tags.at(tagName);
+            if (fromAnd) indexOnly = false;
 
             cursors.reserve(filterSet.size());
             for (uint64_t i = 0; i < filterSet.size(); i++) {

--- a/src/DBQuery.h
+++ b/src/DBQuery.h
@@ -130,8 +130,11 @@ struct DBScan : NonCopyable {
                 uint64_t numTags = MAX_U64;
                 auto consider = [&](const auto &map, bool isAnd){
                     for (const auto &[tn, filterSet] : map) {
-                        if (filterSet.size() < numTags) {
-                            numTags = filterSet.size();
+                        size_t filterSize = filterSet.size();
+                        if (filterSize == 0) continue;
+                        uint64_t cost = isAnd ? 1 : filterSize;
+                        if (cost < numTags || (cost == numTags && isAnd && !fromAnd)) {
+                            numTags = cost;
                             tagName = tn;
                             fromAnd = isAnd;
                         }
@@ -145,11 +148,24 @@ struct DBScan : NonCopyable {
             const auto &filterSet = fromAnd ? f.tagsAnd.at(tagName) : f.tags.at(tagName);
             if (fromAnd) indexOnly = false;
 
-            cursors.reserve(filterSet.size());
-            for (uint64_t i = 0; i < filterSet.size(); i++) {
+            std::vector<std::string> searchVals;
+            if (fromAnd) {
+                // For AND filters, matching any single required value implies the event also contains
+                // every other AND value (otherwise it will be rejected later), so only scan using one
+                // value to avoid redundant cursor work.
+                searchVals.emplace_back(filterSet.at(0));
+            } else {
+                searchVals.reserve(filterSet.size());
+                for (uint64_t i = 0; i < filterSet.size(); i++) {
+                    searchVals.emplace_back(filterSet.at(i));
+                }
+            }
+
+            cursors.reserve(searchVals.size());
+            for (const auto &val : searchVals) {
                 std::string search;
                 search += tagName;
-                search += filterSet.at(i);
+                search += val;
 
                 cursors.emplace_back(
                     search + std::string(8, '\xFF'),

--- a/src/filters.h
+++ b/src/filters.h
@@ -39,6 +39,25 @@ struct FilterSetBytes {
         if (buf.size() > 65535) throw herr("total filter items too large");
     }
 
+    // Direct constructor from already-decoded values
+    FilterSetBytes(const std::vector<std::string> &arrBytes, size_t minSize, size_t maxSize) {
+        if (maxSize > MAX_INDEXED_TAG_VAL_SIZE) throw herr("maxSize bigger than max indexed tag size");
+
+        std::vector<std::string> arr = arrBytes;
+        std::sort(arr.begin(), arr.end());
+
+        for (size_t i = 0; i < arr.size(); i++) {
+            const auto &item = arr[i];
+            if (item.size() < minSize) throw herr("filter item too small");
+            if (item.size() > maxSize) throw herr("filter item too large");
+            if (i > 0 && item == arr[i - 1]) continue; // remove duplicates
+            items.emplace_back(Item{ (uint16_t)buf.size(), (uint8_t)item.size(), (uint8_t)item[0] });
+            buf += item;
+        }
+
+        if (buf.size() > 65535) throw herr("total filter items too large");
+    }
+
     std::string at(size_t n) const {
         if (n >= items.size()) throw herr("FilterSetBytes access out of bounds");
         auto &item = items[n];
@@ -111,6 +130,7 @@ struct NostrFilter {
     std::optional<FilterSetBytes> authors;
     std::optional<FilterSetUint> kinds;
     flat_hash_map<char, FilterSetBytes> tags;
+    flat_hash_map<char, FilterSetBytes> tagsAnd;
 
     uint64_t since = 0;
     uint64_t until = MAX_U64;
@@ -119,7 +139,10 @@ struct NostrFilter {
     bool indexOnlyScans = false;
 
     explicit NostrFilter(const tao::json::value &filterObj, uint64_t maxFilterLimit) {
-        uint64_t numMajorFields = 0;
+        uint64_t numMajorFieldsNonTag = 0;
+        flat_hash_set<char> tagKeySet;
+        flat_hash_map<char, std::vector<std::string>> rawTagsOr;
+        flat_hash_map<char, std::vector<std::string>> rawTagsAnd;
 
         if (!filterObj.is_object()) throw herr("provided filter is not an object");
 
@@ -131,25 +154,27 @@ struct NostrFilter {
 
             if (k == "ids") {
                 ids.emplace(v, true, 32, 32);
-                numMajorFields++;
+                numMajorFieldsNonTag++;
             } else if (k == "authors") {
                 authors.emplace(v, true, 32, 32);
-                numMajorFields++;
+                numMajorFieldsNonTag++;
             } else if (k == "kinds") {
                 kinds.emplace(v);
-                numMajorFields++;
-            } else if (k.starts_with('#')) {
-                numMajorFields++;
-                if (k.size() == 2) {
-                    char tag = k[1];
+                numMajorFieldsNonTag++;
+            } else if (k.starts_with('#') || k.starts_with('&')) {
+                bool isAnd = k.starts_with('&');
+                if (k.size() != 2) throw herr(isAnd ? "unindexed AND tag filter" : "unindexed tag filter");
 
+                char tag = k[1];
+                tagKeySet.insert(tag);
+
+                auto &vec = isAnd ? rawTagsAnd[tag] : rawTagsOr[tag];
+                for (const auto &elem : v.get_array()) {
                     if (tag == 'p' || tag == 'e') {
-                        tags.emplace(tag, FilterSetBytes(v, true, 32, 32));
+                        vec.emplace_back(from_hex(elem.get_string(), false));
                     } else {
-                        tags.emplace(tag, FilterSetBytes(v, false, 0, MAX_INDEXED_TAG_VAL_SIZE));
+                        vec.emplace_back(elem.get_string());
                     }
-                } else {
-                    throw herr("unindexed tag filter");
                 }
             } else if (k == "since") {
                 since = v.get_unsigned();
@@ -162,11 +187,49 @@ struct NostrFilter {
             }
         }
 
-        if (tags.size() > 3) throw herr("too many tags in filter"); // O(N^2) in matching, just prohibit it
+        // Build AND sets first
+        for (const auto &[tagName, vals] : rawTagsAnd) {
+            if (tagName == 'p' || tagName == 'e') {
+                tagsAnd.emplace(tagName, FilterSetBytes(vals, 32, 32));
+            } else {
+                tagsAnd.emplace(tagName, FilterSetBytes(vals, 0, MAX_INDEXED_TAG_VAL_SIZE));
+            }
+        }
+
+        // Build OR sets, skipping any values present in AND for the same tag
+        for (const auto &[tagName, vals] : rawTagsOr) {
+            const auto andIt = tagsAnd.find(tagName);
+            std::vector<std::string> filtered;
+            filtered.reserve(vals.size());
+
+            for (const auto &v : vals) {
+                if (andIt != tagsAnd.end() && andIt->second.doesMatch(v)) continue;
+                filtered.emplace_back(v);
+            }
+
+            if (filtered.empty()) continue;
+
+            if (tagName == 'p' || tagName == 'e') {
+                tags.emplace(tagName, FilterSetBytes(filtered, 32, 32));
+            } else {
+                tags.emplace(tagName, FilterSetBytes(filtered, 0, MAX_INDEXED_TAG_VAL_SIZE));
+            }
+        }
+
+        size_t tagKeyCount = 0;
+        {
+            // tagKeySet already contains the union of keys seen in # and &
+            tagKeyCount = tagKeySet.size();
+        }
+
+        if (tagKeyCount > 3) throw herr("too many tags in filter"); // O(N^2) in matching, just prohibit it
 
         if (limit > maxFilterLimit) limit = maxFilterLimit;
 
+        uint64_t numMajorFields = numMajorFieldsNonTag + tagKeyCount;
+
         indexOnlyScans = (numMajorFields <= 1) || (numMajorFields == 2 && authors && kinds);
+        if (tagsAnd.size()) indexOnlyScans = false; // AND semantics require reading full events
     }
 
     bool doesMatchTimes(uint64_t created) const {
@@ -183,6 +246,24 @@ struct NostrFilter {
         if (ids && !ids->doesMatch(ev.id())) return false;
         if (authors && !authors->doesMatch(ev.pubkey())) return false;
         if (kinds && !kinds->doesMatch(ev.kind())) return false;
+
+        // AND tags: every value in tagsAnd[tag] must be present in the event
+        for (const auto &[tag, filt] : tagsAnd) {
+            for (size_t i = 0; i < filt.size(); i++) {
+                auto requiredVal = filt.at(i);
+                bool foundMatch = false;
+
+                ev.foreachTag([&](char tagName, std::string_view tagVal){
+                    if (tagName == tag && tagVal == requiredVal) {
+                        foundMatch = true;
+                        return false;
+                    }
+                    return true;
+                });
+
+                if (!foundMatch) return false;
+            }
+        }
 
         for (const auto &[tag, filt] : tags) {
             bool foundMatch = false;

--- a/test/dumbFilter.pl
+++ b/test/dumbFilter.pl
@@ -76,41 +76,56 @@ sub doesMatchSingle {
         return 0 if !$found;
     }
 
-    if ($filter->{'#e'}) {
-        my $found;
-        foreach my $search (@{ $filter->{'#e'} }) {
-            foreach my $tag (@{ $ev->{tags} }) {
-                if ($tag->[0] eq 'e' && $tag->[1] eq $search) {
-                    $found = 1;
-                    last;
-                }
-            }
+    # AND / OR tag handling (including NIP-119 AND filters)
+    my %tagAnd;
+    my %tagOr;
+    for my $k (keys %$filter) {
+        if ($k =~ /^#(.)$/) {
+            $tagOr{$1} = $filter->{$k};
+        } elsif ($k =~ /^&(.)$/) {
+            $tagAnd{$1} = $filter->{$k};
         }
-        return 0 if !$found;
     }
 
-    if ($filter->{'#p'}) {
-        my $found;
-        foreach my $search (@{ $filter->{'#p'} }) {
-            foreach my $tag (@{ $ev->{tags} }) {
-                if ($tag->[0] eq 'p' && $tag->[1] eq $search) {
-                    $found = 1;
-                    last;
-                }
-            }
+    # Remove overlaps: AND values are ignored in OR sets for the same tag
+    for my $tag (keys %tagAnd) {
+        next unless $tagOr{$tag};
+        my %andVals = map { $_ => 1 } @{ $tagAnd{$tag} };
+        my @remaining = grep { !exists $andVals{$_} } @{ $tagOr{$tag} };
+        if (@remaining) {
+            $tagOr{$tag} = \@remaining;
+        } else {
+            delete $tagOr{$tag};
         }
-        return 0 if !$found;
     }
 
-    if ($filter->{'#t'}) {
-        my $found;
-        foreach my $search (@{ $filter->{'#t'} }) {
-            foreach my $tag (@{ $ev->{tags} }) {
-                if ($tag->[0] eq 't' && $tag->[1] eq $search) {
+    # AND: every required value must be present
+    for my $tag (keys %tagAnd) {
+        for my $required (@{ $tagAnd{$tag} }) {
+            my $found;
+            foreach my $evTag (@{ $ev->{tags} }) {
+                next if @$evTag < 2;
+                if ($evTag->[0] eq $tag && $evTag->[1] eq $required) {
                     $found = 1;
                     last;
                 }
             }
+            return 0 if !$found;
+        }
+    }
+
+    # OR: at least one value must be present per tag key
+    for my $tag (keys %tagOr) {
+        my $found;
+        foreach my $search (@{ $tagOr{$tag} }) {
+            foreach my $evTag (@{ $ev->{tags} }) {
+                next if @$evTag < 2;
+                if ($evTag->[0] eq $tag && $evTag->[1] eq $search) {
+                    $found = 1;
+                    last;
+                }
+            }
+            last if $found;
         }
         return 0 if !$found;
     }

--- a/test/filterFuzzTest.pl
+++ b/test/filterFuzzTest.pl
@@ -151,6 +151,27 @@ sub genRandomFilterGroup {
                     push @{$f->{'#t'}}, $topics->[int(rand() * @$topics)];
                 }
             }
+
+            if (rand() < .12) {
+                $f->{'&t'} = [];
+                for (1..(rand()*3)+1) {
+                    push @{$f->{'&t'}}, $topics->[int(rand() * @$topics)];
+                }
+            }
+
+            if (rand() < .08) {
+                $f->{'&e'} = [];
+                for (1..(rand()*4)+1) {
+                    push @{$f->{'&e'}}, $ids->[int(rand() * @$ids)];
+                }
+            }
+
+            if (rand() < .08) {
+                $f->{'&p'} = [];
+                for (1..(rand()*3)+1) {
+                    push @{$f->{'&p'}}, $pubkeys->[int(rand() * @$pubkeys)];
+                }
+            }
         }
 
         if (rand() < .2) {


### PR DESCRIPTION
# NIP-91 AND tag filters

## Intent

- Implement NIP-91-style AND semantics for tag filters using `&<tag>` keys while preserving existing OR behavior for `#<tag>`.
- Keep the DB query engine, monitor engine and Perl reference filter in sync on tag semantics without regressing performance.

## Changes

- `src/filters.h`:
  - Extend `NostrFilter` with `tagsAnd` to represent ANDed tag values and track unique tag keys across `#` and `&`.
  - Parse `&<tag>` keys, hex-decode `&e`/`&p`, and normalise values via `FilterSetBytes`, de-duplicating overlaps so values present in `&` are removed from the corresponding `#`.
  - Adjust `indexOnlyScans` so presence of any AND tag forces full-event scans and keeps the 3-tag-key limit based on the union of `#` and `&` keys.
- `src/DBQuery.h`:
  - Allow tag-based scans to be driven by either `tags` or `tagsAnd`, choosing the most selective tag key.
  - When scanning by an AND tag, use only one value from the AND set for the LMDB cursor and disable index-only mode (full events are re-checked against the remaining AND values).
- `src/ActiveMonitors.h`:
  - Include `tagsAnd` alongside `tags` in the tag monitor index so subscription monitors receive events that satisfy AND tag filters.
- `test/dumbFilter.pl`:
  - Replace hard-coded `#e/#p/#t` logic with generic OR (`#<tag>`) and AND (`&<tag>`) handling to match the NostrFilter implementation, including ignoring values that appear in both AND and OR for the same tag key.
- `test/filterFuzzTest.pl`:
  - Extend fuzzed filters to include `&t`, `&e` and `&p` so scan and monitor fuzz tests cover NIP-91 AND-tag semantics.

## Testing

From the project root:

- Build the binary: `make`.
- Populate a test database as described in `test/README.md` (for example, import the wellordered 500k dataset).
- Run the existing fuzz tests, which exercise the new AND-tag logic:
  - `perl test/filterFuzzTest.pl scan-limit`
  - `perl test/filterFuzzTest.pl scan`
  - `perl test/filterFuzzTest.pl monitor`