### PR TITLE
fix: add missing nip11 info fields [ privacy_policy, terms_of_service, etc ]

### DIFF
--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -80,6 +80,10 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
             if (cfg().relay__info__contact.size()) nip11["contact"] = cfg().relay__info__contact;
             if (cfg().relay__info__pubkey.size()) nip11["pubkey"] = cfg().relay__info__pubkey;
             if (cfg().relay__info__icon.size()) nip11["icon"] = cfg().relay__info__icon;
+            if (cfg().relay__info__banner.size()) nip11["banner"] = cfg().relay__info__banner;
+            if (cfg().relay__info__self.size()) nip11["self"] = cfg().relay__info__self;
+            if (cfg().relay__info__privacy.size()) nip11["privacy_policy"] = cfg().relay__info__privacy;
+            if (cfg().relay__info__terms.size()) nip11["terms_of_service"] = cfg().relay__info__terms;
 
             rendered = preGenerateHttpResponse("application/json", tao::json::to_string(nip11));
             ver = cfg().version();

--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -33,6 +33,18 @@ config:
   - name: relay__info__nips
     desc: "List of supported lists as JSON array, or empty string to use default. Example: \"[1,2]\""
     default: ""
+  - name: relay__info__banner
+    desc: "NIP-11: URL pointing to an image to be used as an banner for the relay"
+    default: ""
+  - name: relay__info__self
+    desc: "NIP-11: Relays own pubkey"
+    default: ""
+  - name: relay__info__privacy
+    desc: "NIP-11: Privacy policy URL"
+    default: ""
+  - name: relay__info__terms
+    desc: "NIP-11: Terms of service URL"
+    default: ""
 
   - name: relay__maxWebsocketPayloadSize
     desc: "Maximum accepted incoming websocket frame size (should be larger than max event)"

--- a/strfry.conf
+++ b/strfry.conf
@@ -62,14 +62,26 @@ relay {
         # NIP-11: Administrative nostr pubkey, for contact purposes
         pubkey = ""
 
+        # NIP-11: Relays own pubkey
+        self = ""
+
         # NIP-11: Alternative administrative contact (email, website, etc)
         contact = ""
 
         # NIP-11: URL pointing to an image to be used as an icon for the relay
         icon = ""
 
+        # NIP-11: URL pointing to an image to be used as an banner for the relay
+        banner = ""
+
         # List of supported lists as JSON array, or empty string to use default. Example: "[1,2]"
         nips = ""
+
+        # NIP-11: Privacy policy URL
+        privacy = ""
+
+        # NIP-11: Terms of service URL
+        terms = ""
     }
 
     # Maximum accepted incoming websocket frame size (should be larger than max event) (restart required)


### PR DESCRIPTION
adds:
- `self`
- `banner`
- `privacy_policy`
- `terms_of_service`
 to the [NIP-11 document](https://github.com/nostr-protocol/nips/blob/master/11.md).