### PR TITLE
fix(bytes32): use memcpy for std::hash to fix macOS build

### DIFF
--- a/src/Bytes32.h
+++ b/src/Bytes32.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <string_view>
@@ -47,8 +48,9 @@ namespace std {
     template<> struct hash<Bytes32> {
         std::size_t operator()(Bytes32 const &b) const {
             static_assert(sizeof(b.buf) == 32);
-            uint64_t *p = (size_t*)&b.buf;
-            return size_t(p[0] ^ p[1] ^ p[2] ^ p[3]);
+            uint64_t words[4];
+            ::memcpy(words, b.buf, sizeof(words));
+            return size_t(words[0] ^ words[1] ^ words[2] ^ words[3]);
         }
     };
 }


### PR DESCRIPTION
This Pull Request fixes/closes #188.

It changes the following:

- Fix `std::hash<Bytes32>` in `src/Bytes32.h`: remove the ill-formed cast from `size_t*` to `uint64_t*` (fails on Apple Clang / arm64 where `size_t` and `uint64_t` are distinct typedefs).
- Hash the 32-byte buffer by copying into `uint64_t words[4]` with `memcpy`, then XOR the four lanes—same hash shape as before, without pointer type punning.
- Include `<cstdint>` so `uint64_t` is explicit in the header.

## Testing

- `make setup-golpe && make -j4` (with dependencies available per README / your environment, e.g. Homebrew `CPATH` / `LIBRARY_PATH` on macOS)
- `make src/Decompressor.o` (quick check that `Bytes32.h` compiles on the inclusion path used by the build)
