### PR TITLE
feat: implement `archival mode` to prevent event deletion

### DIFF
--- a/golpe.yaml
+++ b/golpe.yaml
@@ -150,3 +150,6 @@ config:
   - name: events__maxTagValSize
     desc: "Maximum size for tag values, in bytes"
     default: 1024
+  - name: events__archivalMode
+    desc: "Archival mode: no deleting of events"
+    default: false

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -300,10 +300,11 @@ void writeEvents(lmdb::txn &txn, NegentropyFilterCache &neFilterCache, std::vect
                         if (isEventABeforeEventB(packed, otherPacked)) {
                             ev.status = EventWriteStatus::Replaced;
                         } else {
-                            if (logDeletions) LI << "Deleting event (d-tag). id=" << to_hex(otherPacked.id());
-                            levIdsToDelete.push_back(otherEv.primaryKeyId);
+                            if (!cfg().events__archivalMode) {
+                                if (logDeletions) LI << "Deleting event (d-tag). id=" << to_hex(otherPacked.id());
+                                levIdsToDelete.push_back(otherEv.primaryKeyId);
+                            }
                         }
-
                         return false;
                     }, true);
 
@@ -333,8 +334,10 @@ void writeEvents(lmdb::txn &txn, NegentropyFilterCache &neFilterCache, std::vect
                     if (tagName == 'e') {
                         auto otherEv = lookupEventById(txn, tagVal);
                         if (otherEv && PackedEventView(otherEv->buf).pubkey() == packed.pubkey()) {
-                            if (logDeletions) LI << "Deleting event (kind 5, e-tag). id=" << to_hex(tagVal);
-                            levIdsToDelete.push_back(otherEv->primaryKeyId);
+                            if (!cfg().events__archivalMode) {
+                                if (logDeletions) LI << "Deleting event (kind 5, e-tag). id=" << to_hex(tagVal);
+                                levIdsToDelete.push_back(otherEv->primaryKeyId);
+                            }
                         }
                     } else if (tagName == 'a') {
                         try { // parsing a-tag can fail
@@ -350,8 +353,10 @@ void writeEvents(lmdb::txn &txn, NegentropyFilterCache &neFilterCache, std::vect
                                     auto otherPacked = PackedEventView(otherEv.buf);
 
                                     if (otherPacked.created_at() <= packed.created_at()) {
-                                        if (logDeletions) LI << "Deleting replaceable event (kind 5, a-tag). id=" << to_hex(otherPacked.id());
-                                        levIdsToDelete.push_back(otherEv.primaryKeyId);
+                                        if (!cfg().events__archivalMode) {
+                                            if (logDeletions) LI << "Deleting replaceable event (kind 5, a-tag). id=" << to_hex(otherPacked.id());
+                                            levIdsToDelete.push_back(otherEv.primaryKeyId);
+                                        }
                                     }
 
                                     return false;

--- a/strfry.conf
+++ b/strfry.conf
@@ -37,6 +37,9 @@ events {
 
     # Maximum size for tag values, in bytes
     maxTagValSize = 1024
+
+    # Archival mode: no deleting of events
+    archivalMode = false
 }
 
 relay {


### PR DESCRIPTION
## **TODO**: Archival Mode: no deleting of events

- Add new `events.archivalMode` configuration flag to `strfry.conf`.
- When this flag is enabled, it prevents the deletion of events.