### PR TITLE
feat(relay): make filter tag limit configurable

### DIFF
--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -73,6 +73,9 @@ config:
   - name: relay__maxFilterLimit
     desc: "Maximum records that can be returned per filter"
     default: 500
+  - name: relay__maxTagsPerFilter
+    desc: "Maximum number of tag filters allowed per filter (O(N^2) in matching, so keep it small)"
+    default: 3
   - name: relay__maxFilterLimitCount
     desc: "Maximum records that can be counted by a COUNT request (set 0 to disable COUNT)"
     default: 1000000

--- a/src/filters.h
+++ b/src/filters.h
@@ -203,7 +203,7 @@ struct NostrFilter {
             }
         }
 
-        if (tags.size() > 3) throw herr("too many tags in filter"); // O(N^2) in matching, so prevent it from being too large
+        if (tags.size() > cfg().relay__maxTagsPerFilter) throw herr("too many tags in filter"); // O(N^2) in matching, so prevent it from being too large
 
         if (limit > maxFilterLimit) limit = maxFilterLimit;
 

--- a/strfry.conf
+++ b/strfry.conf
@@ -110,6 +110,9 @@ relay {
     # Maximum records that can be returned per filter
     maxFilterLimit = 500
 
+    # Maximum number of tag filters allowed per filter
+    maxTagsPerFilter = 3
+
     # Maximum records that can be counted by a COUNT request (set 0 to disable COUNT)
     maxFilterLimitCount = 1000000
 


### PR DESCRIPTION
## Description

Currently, the maximum number of tag filters per Nostr filter object is hardcoded. This PR introduces a maxTagsPerFilter config option so relay operators can actually bump this limit if they need to.

## Issue
- Fixes #150 

## Testing

1st Response -> When maxTagsPerFilter config was set to 3
2nd Response -> When maxTagsPerFilter config was changed to 4 from 3

<img width="2880" height="1372" alt="image" src="https://github.com/user-attachments/assets/24dccb4f-b7f3-420e-8c1b-d4b72fa49481" />

- [x] `APPS="dbutils relay mesh" make -j4` succeeds locally.

## Notes

- The default stays at 3, so there's no behavior change for existing setups unless they explicitly raise the limit (which comes with a matching cost warning in the docs).
- Higher values increase worst-case work when matching tags (see comment in config).
