### PR TITLE
Feature: logging and exitcodes styfry sync (#124)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,16 @@ next
     just print out the event IDs that you have and/or need, instead of actually
     trying to transfer them.
   * The amount of bytes sent by negentropy was incorrectly reported in a log.
+  * New --timeout flag for strfry sync. Aborts sync after the specified number
+    of seconds of inactivity, preventing the process from hanging indefinitely
+    when a relay does not support negentropy syncing.
+  * strfry sync now handles NOTICE messages from relays. If a NOTICE is
+    received before any negentropy response, the sync exits with an error,
+    since this indicates the relay does not support the negentropy protocol.
+  * Rejected events no longer log event content. Only the event ID and
+    rejection reason are logged, preventing a potential DoS vector where
+    oversized events could fill disks with log data.
+  * Truncate large messages in sync error/warning logs to 512 bytes.
 
 1.1.0
   * DEPRECATE stream command. Instead, suggest using strfry router

--- a/src/WriterPipeline.h
+++ b/src/WriterPipeline.h
@@ -74,8 +74,11 @@ struct WriterPipeline {
                         parseAndVerifyEvent(m.eventJson, secpCtx, verifyMsg, verifyTime, packedStr, jsonStr);
                     } catch (std::exception &e) {
                         if (verboseReject()) {
-                            jsonStr = tao::json::to_string(m.eventJson).substr(0,200);
-                            LI << "Rejected event: " << jsonStr << " reason: " << e.what();
+                            std::string idHex = "unknown";
+                            try {
+                                if (m.eventJson.is_object()) idHex = m.eventJson.at("id").get_string();
+                            } catch (...) {}
+                            LI << "Rejected event " << idHex << ": " << e.what();
                         }
                         numLive--;
                         totalRejected++;

--- a/src/apps/mesh/cmd_sync.cpp
+++ b/src/apps/mesh/cmd_sync.cpp
@@ -5,6 +5,9 @@
 #include <negentropy/storage/BTreeLMDB.h>
 #include <negentropy/storage/SubRange.h>
 
+#include <hoytech/timer.h>
+#include <cctype>
+
 #include "golpe.h"
 
 #include "Bytes32.h"
@@ -21,7 +24,7 @@
 static const char USAGE[] =
 R"(
     Usage:
-      sync <url> [--dir=<dir>] [--filter=<filter>] [--range=<range>] [--print-missing] [--frame-size-limit=<frame-size-limit>]
+      sync <url> [--dir=<dir>] [--filter=<filter>] [--range=<range>] [--print-missing] [--frame-size-limit=<frame-size-limit>] [--timeout=<timeout>]
 
     Options:
       --dir=<dir>        Direction: both, down, up, none (default: both)
@@ -31,6 +34,7 @@ R"(
                          Units: s=seconds, m=minutes, h=hours, d=days, w=weeks, M=months, Y=years
       --print-missing    Instead of performing a sync, just print out missing record IDs. Implies dir=none.
       --frame-size-limit=<frame-size-limit>  Limit outgoing negentropy message size (default 60k, 0 for no limit)
+      --timeout=<timeout>  Abort sync if no activity for this many seconds (default: 0, no timeout)
 )";
 
 
@@ -63,6 +67,8 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
     uint64_t frameSizeLimit = 60'000; // default frame limit is 128k. Halve that (hex encoding) and subtract a bit (JSON msg overhead)
     if (args["--frame-size-limit"]) frameSizeLimit = args["--frame-size-limit"].asLong();
 
+    uint64_t timeout = 0;
+    if (args["--timeout"]) timeout = args["--timeout"].asLong();
 
     auto filterCompiled = NostrFilterGroup::unwrapped(filterJson);
 
@@ -124,10 +130,13 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
     WSConnection ws(url);
     PluginEventSifter writePolicyPlugin;
 
+    std::atomic<uint64_t> lastActivity{0};
+    std::atomic<bool> timedOut{false};
 
     ws.reconnect = false;
 
     ws.onConnect = [&]{
+        lastActivity = hoytech::curr_time_s();
         auto txn = env.txn_ro();
         std::string neMsg;
 
@@ -169,15 +178,19 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
     std::vector<Bytes32> have, need;
     flat_hash_set<Bytes32> seenHave, seenNeed;
     bool syncDone = false;
+    bool receivedNegMsg = false;
     uint64_t totalHaves = 0, totalNeeds = 0;
     Decompressor decomp;
 
     ws.onMessage = [&](auto msgStr, uWS::OpCode opCode, size_t compressedSize){
+        lastActivity = hoytech::curr_time_s();
+
         try {
             auto txn = env.txn_ro();
             tao::json::value msg = tao::json::from_string(msgStr);
 
             if (msg.at(0) == "NEG-MSG") {
+                receivedNegMsg = true;
                 uint64_t origHaves = have.size(), origNeeds = need.size();
 
                 std::optional<std::string> neMsg;
@@ -264,12 +277,34 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
             } else if (msg.at(0) == "NEG-ERR") {
                 LE << "Got NEG-ERR response from relay: " << msg;
                 doExit(1);
+            } else if (msg.at(0) == "NOTICE") {
+                auto noticeStr = msg.at(1).get_string();
+                LW << "NOTICE from relay: " << noticeStr;
+
+                if (!receivedNegMsg) {
+                    std::string lowerNotice = noticeStr;
+                    std::transform(lowerNotice.begin(), lowerNotice.end(), lowerNotice.begin(),
+                        [](unsigned char c){ return std::tolower(c); });
+
+                    bool isError = false;
+                    for (const char* kw : {"error", "invalid", "unrecognized", "bad msg", "bad message", "could not parse", "disabled", "unsupported", "unknown"}) {
+                        if (lowerNotice.find(kw) != std::string::npos) {
+                            isError = true;
+                            break;
+                        }
+                    }
+
+                    if (isError) {
+                        LE << "Received error NOTICE before any negentropy response, relay likely does not support negentropy syncing";
+                        doExit(1);
+                    }
+                }
             } else {
-                LW << "Unexpected message from relay: " << msg;
+                LW << "Unexpected message from relay: " << tao::json::to_string(msg).substr(0, 512);
             }
         } catch (std::exception &e) {
             LE << "Error processing websocket message: " << e.what();
-            LW << "MSG: " << msgStr;
+            LW << "MSG: " << msgStr.substr(0, 512);
         }
 
         if (doUp && have.size() > 0 && inFlightUp <= lowWaterUp) {
@@ -329,6 +364,29 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
             doExit(0);
         }
     };
+
+    ws.onTrigger = [&]{
+        if (timedOut) {
+            LE << "Sync timed out: no activity for " << timeout << " seconds";
+            doExit(1);
+        }
+    };
+
+    hoytech::timer timeoutTimer;
+
+    if (timeout > 0) {
+        timeoutTimer.setupCb = []{ setThreadName("syncTimeout"); };
+        timeoutTimer.repeat(1'000'000, [&]{ // 1 second
+            if (ws.shutdown) return;
+            auto now = hoytech::curr_time_s();
+            auto last = lastActivity.load();
+            if (last > 0 && now - last >= timeout) {
+                timedOut = true;
+                ws.trigger();
+            }
+        });
+        timeoutTimer.run();
+    }
 
     ws.run();
 }


### PR DESCRIPTION

**Description**

This PR addresses three issues reported in #124 related to the `strfry sync` command hanging indefinitely, oversized event content leaking into logs, and unhelpful error handling when connecting to relays that do not support negentropy.

**Changes included:**

**Inactivity Timeout for `strfry sync`:**
- Added `--timeout=<seconds>` CLI flag to `cmd_sync.cpp`. When set, the sync process aborts with exit code 1 if no WebSocket activity is observed for the specified duration.
- Implemented using `hoytech::timer` (the same pattern used by `RelayCron` and `cmd_router`) with a 1-second tick and `std::atomic<uint64_t> lastActivity` updated on every `onConnect` and `onMessage` event.
- Timeout fires via `ws.trigger()` → `ws.onTrigger` to ensure the exit runs on the WebSocket thread, consistent with the existing `cmd_stream.cpp` trigger pattern.
- Defaults to `0` (disabled) for full backward compatibility.

**NOTICE Error Detection:**
- Added a `NOTICE` message handler in `cmd_sync.cpp`. If a `NOTICE` is received before any `NEG-MSG` response (tracked by `bool receivedNegMsg`), and the notice text matches common error keywords (case-insensitive), the sync exits with code 1 and a clear log message indicating the relay likely does not support negentropy.
- This directly addresses the observed behavior where relays responding with `"ERROR: negentropy disabled"`, `"bad message type"`, `"Command unrecognized"`, etc. caused the sync process to hang indefinitely.
- Non-error NOTICEs and NOTICEs received after a successful NEG-MSG exchange are logged as warnings and do not abort the sync.

**Remove Event Content from Rejection Logs (`WriterPipeline.h`):**
- Previously, rejected events were logged with up to 200 characters of their raw JSON content, creating a potential DoS vector where an attacker could send oversized events to fill relay disks with log data.
- Now only the event's hex ID and rejection reason are logged: `Rejected event <id>: <reason>`. Falls back to `"unknown"` if the ID cannot be parsed.
- This change affects all consumers of `WriterPipeline` (sync, import, router).

**Truncate Large Messages in Error Paths:**
- Unexpected messages and catch-all error log lines in `cmd_sync.cpp` now truncate the raw message string to 512 characters, preventing unbounded log growth from malformed or adversarial relay messages.

**Related Issue**

Closes #124

**Motivation and Context**

Users running `strfry sync` in automated pipelines against many relays encountered processes hanging indefinitely when relays did not support the negentropy protocol (NIP-77). These relays send a human-readable `NOTICE` instead of a `NEG-ERR`, leaving `strfry sync` waiting forever with no way to detect the failure. The `--timeout` flag and NOTICE detection together ensure the process always terminates with a meaningful exit code. Additionally, the rejection logging change eliminates a disk-fill vector that could be triggered by any client sending oversized events to a relay running sync or import.

**How Has This Been Tested?**

Functionally tested against live Nostr relays in WSL Ubuntu:
- `--timeout` flag verified present in `--help` output and confirmed it does not fire during an active sync against a responsive relay (`relay.damus.io`).
- NOTICE detection verified against `nos.lol` and `nostr.mom` (both respond with `"ERROR: bad msg: negentropy disabled"`): sync exits with code 1 within ~1 second instead of hanging.
- Rejection logging verified: large events rejected during a sync against `relay.damus.io` produce log lines of the form `Rejected event <hex_id>: event too large: <size>` with no event content.
- Full project builds cleanly with `make`.

**Types of changes**
- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (`CHANGES` file).
- [x] All new and existing tests passed.