### PR TITLE
add write-path performance metrics and connection gauge to prometheus

### DIFF
--- a/src/PrometheusMetrics.h
+++ b/src/PrometheusMetrics.h
@@ -27,6 +27,29 @@ public:
         }
     };
 
+    // Gauge for tracking current values that can go up and down
+    class Gauge {
+    private:
+        std::atomic<int64_t> value{0};
+
+    public:
+        void inc(int64_t n = 1) {
+            value.fetch_add(n, std::memory_order_relaxed);
+        }
+
+        void dec(int64_t n = 1) {
+            value.fetch_sub(n, std::memory_order_relaxed);
+        }
+
+        void set(int64_t v) {
+            value.store(v, std::memory_order_relaxed);
+        }
+
+        int64_t get() const {
+            return value.load(std::memory_order_relaxed);
+        }
+    };
+
     // Labeled counter - allows multiple counters with different label values
     class LabeledCounter {
     private:
@@ -75,6 +98,16 @@ public:
     // Nostr event counters (by kind)
     LabeledCounter nostrEventsByKind;
 
+    // Write path performance metrics
+    Counter writtenEventsTotal;
+    Counter rejectedEventsTotal;
+    Counter dupEventsTotal;
+    Counter writeTimeUs;  // total microseconds spent in write transactions
+    Gauge lastWriteBatchSize;
+
+    // Connection tracking
+    Gauge activeConnections;
+
     // Generate Prometheus text format output
     std::string render() const {
         std::ostringstream out;
@@ -102,7 +135,33 @@ public:
         for (const auto& [kind, count] : events) {
             out << "nostr_events_total{kind=\"" << kind << "\"} " << count << "\n";
         }
-        
+
+        // Write path metrics
+        out << "# HELP strfry_write_events_total Total events written to DB\n";
+        out << "# TYPE strfry_write_events_total counter\n";
+        out << "strfry_write_events_total " << writtenEventsTotal.get() << "\n";
+
+        out << "# HELP strfry_write_rejected_total Total events rejected during write\n";
+        out << "# TYPE strfry_write_rejected_total counter\n";
+        out << "strfry_write_rejected_total " << rejectedEventsTotal.get() << "\n";
+
+        out << "# HELP strfry_write_dups_total Total duplicate events skipped\n";
+        out << "# TYPE strfry_write_dups_total counter\n";
+        out << "strfry_write_dups_total " << dupEventsTotal.get() << "\n";
+
+        out << "# HELP strfry_write_time_microseconds_total Total time in write transactions\n";
+        out << "# TYPE strfry_write_time_microseconds_total counter\n";
+        out << "strfry_write_time_microseconds_total " << writeTimeUs.get() << "\n";
+
+        out << "# HELP strfry_write_batch_size Size of last write batch\n";
+        out << "# TYPE strfry_write_batch_size gauge\n";
+        out << "strfry_write_batch_size " << lastWriteBatchSize.get() << "\n";
+
+        // Connection tracking
+        out << "# HELP strfry_connections_current Current number of active WebSocket connections\n";
+        out << "# TYPE strfry_connections_current gauge\n";
+        out << "strfry_connections_current " << activeConnections.get() << "\n";
+
         return out.str();
     }
 

--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -4,6 +4,7 @@
 #include "app_git_version.h"
 #include "Favicon.h"
 #include "Bech32Utils.h"
+#include "PrometheusMetrics.h"
 
 
 
@@ -277,6 +278,8 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
            << " sliding=" << (compSlidingWindow ? 'Y' : 'N')
         ;
 
+        PrometheusMetrics::getInstance().activeConnections.inc();
+
         if (cfg().relay__enableTcpKeepalive) {
             int optval = 1;
             if (setsockopt(ws->getFd(), SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval))) {
@@ -302,6 +305,8 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
 
         connIdToConnection.erase(connId);
         delete c;
+
+        PrometheusMetrics::getInstance().activeConnections.dec();
 
         if (gracefulShutdown) {
             LI << "Graceful shutdown in progress: " << connIdToConnection.size() << " connections remaining";

--- a/src/apps/relay/RelayWriter.cpp
+++ b/src/apps/relay/RelayWriter.cpp
@@ -1,6 +1,7 @@
 #include "RelayServer.h"
 
 #include "PluginEventSifter.h"
+#include "PrometheusMetrics.h"
 
 
 void RelayServer::runWriter(ThreadPool<MsgWriter>::Thread &thr) {
@@ -61,9 +62,14 @@ void RelayServer::runWriter(ThreadPool<MsgWriter>::Thread &thr) {
         // Do write
 
         try {
+            auto t0 = std::chrono::steady_clock::now();
             auto txn = env.txn_rw();
             writeEvents(txn, neFilterCache, newEvents);
             txn.commit();
+            auto t1 = std::chrono::steady_clock::now();
+            auto us = std::chrono::duration_cast<std::chrono::microseconds>(t1 - t0).count();
+            PrometheusMetrics::getInstance().writeTimeUs.inc(us);
+            PrometheusMetrics::getInstance().lastWriteBatchSize.set(newEvents.size());
         } catch (std::exception &e) {
             LE << "Error writing " << newEvents.size() << " events: " << e.what();
 
@@ -92,13 +98,17 @@ void RelayServer::runWriter(ThreadPool<MsgWriter>::Thread &thr) {
             if (newEvent.status == EventWriteStatus::Written) {
                 LI << "Inserted event. id=" << eventIdHex << " levId=" << newEvent.levId;
                 written = true;
+                PrometheusMetrics::getInstance().writtenEventsTotal.inc();
             } else if (newEvent.status == EventWriteStatus::Duplicate) {
                 message = "duplicate: have this event";
                 written = true;
+                PrometheusMetrics::getInstance().dupEventsTotal.inc();
             } else if (newEvent.status == EventWriteStatus::Replaced) {
                 message = "replaced: have newer event";
+                PrometheusMetrics::getInstance().rejectedEventsTotal.inc();
             } else if (newEvent.status == EventWriteStatus::Deleted) {
                 message = "deleted: user requested deletion";
+                PrometheusMetrics::getInstance().rejectedEventsTotal.inc();
             }
 
             if (newEvent.status != EventWriteStatus::Written) {


### PR DESCRIPTION
The existing prometheus endpoint tracks message counts by verb/kind but has no visibility into the write path. This adds counters for events written/rejected/duplicated, cumulative write transaction time, last batch size, and current connection count.

Also adds a Gauge type to PrometheusMetrics since batch size and connection count go up and down.

Tested by running the relay under load with nostr-bench and verifying the metrics update at /metrics.
