### PR TITLE
Feature: log bytes up/down and compression ratios (#196)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ next
     just print out the event IDs that you have and/or need, instead of actually
     trying to transfer them.
   * The amount of bytes sent by negentropy was incorrectly reported in a log.
+  * Sync, stream, upload, download, and router now log bytes up/down and
+    compression ratios on disconnect. This mirrors the per-connection bandwidth
+    stats already tracked by the relay server.
 
 1.1.0
   * DEPRECATE stream command. Instead, suggest using strfry router

--- a/src/WSConnection.h
+++ b/src/WSConnection.h
@@ -18,6 +18,13 @@ class WSConnection : NonCopyable {
 
   public:
 
+    struct Stats {
+        uint64_t bytesUp = 0;
+        uint64_t bytesUpCompressed = 0;
+        uint64_t bytesDown = 0;
+        uint64_t bytesDownCompressed = 0;
+    } stats;
+
     WSConnection(const std::string &url) : url(url) {}
 
     std::function<void()> onConnect;
@@ -42,7 +49,11 @@ class WSConnection : NonCopyable {
     // Should only be called from the websocket thread (ie within an onConnect or onMessage callback)
     void send(std::string_view msg, uWS::OpCode op = uWS::OpCode::TEXT, size_t *compressedSize = nullptr) {
         if (currWs) {
-            currWs->send(msg.data(), msg.size(), op, nullptr, nullptr, true, compressedSize);
+            size_t localCompressedSize;
+            size_t *csPtr = compressedSize ? compressedSize : &localCompressedSize;
+            currWs->send(msg.data(), msg.size(), op, nullptr, nullptr, true, csPtr);
+            stats.bytesUp += msg.size();
+            stats.bytesUpCompressed += *csPtr;
         } else {
             LI << "Tried to send message, but websocket is disconnected";
         }
@@ -72,6 +83,7 @@ class WSConnection : NonCopyable {
                 currWs = nullptr;
             }
 
+            stats = Stats{};
             remoteAddr = ws->getAddress().address;
             LI << "Connected to " << url << " (" << remoteAddr << ")";
 
@@ -93,7 +105,12 @@ class WSConnection : NonCopyable {
         });
 
         hubGroup->onDisconnection([&](uWS::WebSocket<uWS::CLIENT> *ws, int code, char *message, size_t length) {
-            LI << "Disconnected from " << url << " : " << code << "/" << (message ? std::string_view(message, length) : "-");
+            auto upComp = renderPercent(stats.bytesUp ? 1.0 - (double)stats.bytesUpCompressed / stats.bytesUp : 0);
+            auto downComp = renderPercent(stats.bytesDown ? 1.0 - (double)stats.bytesDownCompressed / stats.bytesDown : 0);
+
+            LI << "Disconnected from " << url << " : " << code << "/" << (message ? std::string_view(message, length) : "-")
+               << " UP: " << renderSize(stats.bytesUp) << " (" << upComp << " compressed)"
+               << " DN: " << renderSize(stats.bytesDown) << " (" << downComp << " compressed)";
 
             if (shutdown) return;
 
@@ -115,6 +132,9 @@ class WSConnection : NonCopyable {
         });
 
         hubGroup->onMessage2([&](uWS::WebSocket<uWS::CLIENT> *ws, char *message, size_t length, uWS::OpCode opCode, size_t compressedSize) {
+            stats.bytesDown += length;
+            stats.bytesDownCompressed += compressedSize;
+
             if (!onMessage) return;
 
             try {

--- a/src/apps/mesh/cmd_router.cpp
+++ b/src/apps/mesh/cmd_router.cpp
@@ -41,6 +41,13 @@ struct RouterEvent : NonCopyable {
 struct ConnDesignator {
     std::string groupName;
     std::string url;
+
+    struct Stats {
+        uint64_t bytesUp = 0;
+        uint64_t bytesUpCompressed = 0;
+        uint64_t bytesDown = 0;
+        uint64_t bytesDownCompressed = 0;
+    } stats;
 };
 
 
@@ -164,7 +171,11 @@ struct Router {
                 filterToSend["limit"] = 0;
 
                 auto msg = tao::json::to_string(tao::json::value::array({ "REQ", "X", filterToSend }));
-                ws->send(msg.data(), msg.size(), uWS::OpCode::TEXT, nullptr, nullptr, true);
+                size_t compressedSize;
+                ws->send(msg.data(), msg.size(), uWS::OpCode::TEXT, nullptr, nullptr, true, &compressedSize);
+                auto *desig = (ConnDesignator*) ws->getUserData();
+                desig->stats.bytesUp += msg.size();
+                desig->stats.bytesUpCompressed += compressedSize;
             }
         }
 
@@ -209,7 +220,13 @@ struct Router {
             auto res = pluginUp.acceptEvent(pluginUpCmd, evJson, EventSourceType::Stored, "", Bytes32(), okMsg);
             if (res == PluginEventSifterResult::Accept) {
                 for (auto &[url, c] : conns) {
-                    if (c.ws) c.ws->send(responseStr.data(), responseStr.size(), uWS::OpCode::TEXT, nullptr, nullptr, true);
+                    if (c.ws) {
+                        size_t compressedSize;
+                        c.ws->send(responseStr.data(), responseStr.size(), uWS::OpCode::TEXT, nullptr, nullptr, true, &compressedSize);
+                        auto *desig = (ConnDesignator*) c.ws->getUserData();
+                        desig->stats.bytesUp += responseStr.size();
+                        desig->stats.bytesUpCompressed += compressedSize;
+                    }
                 }
             } else {
                 if (okMsg.size()) LI << groupName << " : pluginUp blocked event " << evJson.at("id").get_string() << ": " << okMsg;
@@ -261,7 +278,14 @@ struct Router {
 
         hubGroup->onDisconnection([&](uWS::WebSocket<uWS::CLIENT> *ws, int code, char *message, size_t length) {
             auto *desig = (ConnDesignator*) ws->getUserData();
-            LI << desig->groupName << ": Disconnected from " << desig->url;
+
+            auto &st = desig->stats;
+            auto upComp = renderPercent(st.bytesUp ? 1.0 - (double)st.bytesUpCompressed / st.bytesUp : 0);
+            auto downComp = renderPercent(st.bytesDown ? 1.0 - (double)st.bytesDownCompressed / st.bytesDown : 0);
+
+            LI << desig->groupName << ": Disconnected from " << desig->url
+               << " UP: " << renderSize(st.bytesUp) << " (" << upComp << " compressed)"
+               << " DN: " << renderSize(st.bytesDown) << " (" << downComp << " compressed)";
 
             if (streamGroups.contains(desig->groupName)) {
                 streamGroups.at(desig->groupName).connClose(desig->url, ws);
@@ -277,8 +301,10 @@ struct Router {
             delete desig;
         });
 
-        hubGroup->onMessage2([&](uWS::WebSocket<uWS::CLIENT> *ws, char *message, size_t length, uWS::OpCode, size_t) {
+        hubGroup->onMessage2([&](uWS::WebSocket<uWS::CLIENT> *ws, char *message, size_t length, uWS::OpCode, size_t compressedSize) {
             auto *desig = (ConnDesignator*) ws->getUserData();
+            desig->stats.bytesDown += length;
+            desig->stats.bytesDownCompressed += compressedSize;
 
             if (!streamGroups.contains(desig->groupName)) {
                 ws->close();

--- a/src/apps/mesh/cmd_sync.cpp
+++ b/src/apps/mesh/cmd_sync.cpp
@@ -153,6 +153,12 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
     };
 
     auto doExit = [&](int status){
+        auto &st = ws.stats;
+        auto upComp = renderPercent(st.bytesUp ? 1.0 - (double)st.bytesUpCompressed / st.bytesUp : 0);
+        auto downComp = renderPercent(st.bytesDown ? 1.0 - (double)st.bytesDownCompressed / st.bytesDown : 0);
+        LI << "Sync transfer stats  UP: " << renderSize(st.bytesUp) << " (" << upComp << " compressed)"
+           << "  DN: " << renderSize(st.bytesDown) << " (" << downComp << " compressed)";
+
         if (doDown) writer.flush();
         ::exit(status);
     };


### PR DESCRIPTION

## Description

This PR addresses and closes #196  adds bandwidth logging (bytes up/down and compression ratios) to the mesh client commands (`sync`, `stream`, `upload`, `download`, `router`), mirroring the per-connection stats that the relay server already tracks in `RelayWebsocket.cpp`.

Currently operators have no visibility into how much data flows through sync/stream/router connections, or how effective WebSocket compression is. This information is already tracked on the relay server side but was absent from the mesh client side, despite `WSConnection` and `onMessage2` already exposing `compressedSize`.

**Changes included:**

**Byte counters in `WSConnection.h`:**

- Added a `Stats` struct (identical to `RelayWebsocket.cpp`'s `Connection::Stats`) with `bytesUp`, `bytesUpCompressed`, `bytesDown`, `bytesDownCompressed`.
- `send()` now always captures `compressedSize` and accumulates into `stats.bytesUp` / `stats.bytesUpCompressed`. Previously the `compressedSize` out-parameter was optional and unused by most callers.
- `onMessage2` accumulates `stats.bytesDown` / `stats.bytesDownCompressed` before forwarding to the user callback.
- `onDisconnection` logs a bandwidth summary using the existing `renderSize()` / `renderPercent()` helpers — same format the relay server uses.
- `onConnection` resets stats with `stats = Stats{}` so reconnects (used by `stream`) get clean per-connection stats, matching the relay's per-connection lifecycle.

This automatically covers `cmd_stream.cpp`, `cmd_upload.cpp`, and `cmd_download.cpp` with no changes to those files.

**Sync completion summary in `cmd_sync.cpp`:**

- Added a bandwidth summary log line in `doExit()` so stats are reported when the sync process exits. This fires before `::exit()` since the uWS event loop teardown does not reliably invoke the disconnect handler.

**Router per-connection stats in `cmd_router.cpp`:**

- Router uses raw `uWS::WebSocket<CLIENT>*` instead of `WSConnection`, so it needed its own plumbing.
- Added a `Stats` struct to `ConnDesignator` (the per-connection user data).
- Tracked outgoing bytes in `connOpen()` (initial REQ) and `outgoingEvent()` (event upload), and incoming bytes in `onMessage2`.
- Logged the bandwidth summary in `onDisconnection`.

**Example output:**
```
Sync transfer stats  UP: 227b (7.5% compressed)  DN: 867b (29.0% compressed)
```
```
mygroup: Disconnected from wss://relay.example.com UP: 14.12M (62.3% compressed) DN: 2.30M (41.8% compressed)
```

## Related Issue

#196 

## Motivation and Context

Operators running relay meshes or automated sync pipelines have no way to monitor how much bandwidth each connection consumes, or whether compression dictionaries and WebSocket `permessage-deflate` are actually helping. The relay server already logs this on disconnect (`RelayWebsocket.cpp:292-298`), but the mesh client side discarded `compressedSize` entirely. This change closes that gap by propagating the data that was already available through `WSConnection` and the router's raw WebSocket paths.

## How Has This Been Tested?

Functionally tested against live Nostr relays in WSL Ubuntu:

- Built cleanly with `make -j4` — zero errors, zero warnings from changed files.
- Synced against `relay.damus.io` with a single-author filter (`--dir down`): confirmed `Sync transfer stats  UP: 227b (7.5% compressed)  DN: 867b (29.0% compressed)` appears at completion.
- Synced when already in sync (have 0, need 0): confirmed stats show protocol overhead only: `UP: 203b (19.2% compressed)  DN: 92b (10.9% compressed)`.
- Connection error path: confirmed zero-byte stats log gracefully as `UP: 0b (0.0% compressed)  DN: 0b (0.0% compressed)` — no division-by-zero crash.
- Verified `cmd_upload.cpp`, `cmd_download.cpp`, and `cmd_stream.cpp` inherit the `WSConnection` disconnect log automatically with no code changes.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (CHANGES file).
- [x] All new and existing tests passed.