### PR TITLE
auth: respond with OK instead of NOTICE on failure (NIP-42)

### DIFF
--- a/src/apps/relay/RelayIngester.cpp
+++ b/src/apps/relay/RelayIngester.cpp
@@ -43,7 +43,8 @@ void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
                             try {
                                 ingesterProcessAuth(rsctx, msg->connId, arr[1]);
                             } catch (std::exception &e) {
-                                sendNoticeError(msg->connId, std::string("auth failed: ") + e.what());
+                                sendOKResponse(msg->connId, arr[1].is_object() && arr[1].at("id").is_string() ? arr[1].at("id").get_string() : "?",
+                                               false, std::string("error: ") + e.what());
                             }
                         } else if (cmd == "REQ" || cmd == "COUNT") {
                             PROM_INC_CLIENT_MSG(cmd);


### PR DESCRIPTION
Fixes #200

When AUTH verification fails, the catch block was using `sendNoticeError`. NIP-42 says AUTH must be answered with `OK`, same as EVENT. Switched to `sendOKResponse` following the EVENT handler pattern right above it.