### PR TITLE
Add checks to packed event parser to avoid index out of range errors / undefined behavior

### DIFF
--- a/src/PackedEvent.h
+++ b/src/PackedEvent.h
@@ -52,9 +52,12 @@ struct PackedEventView {
     void foreachTag(const std::function<bool(char, std::string_view)> &cb) const {
         std::string_view b = buf.substr(88);
 
-        while (b.size()) {
+        while (b.size() >= 2) {
             char tagName = b[0];
             size_t tagLen = (uint8_t)b[1];
+            
+            if (tagLen > b.size() - 2) break;
+
             bool ret = cb(tagName, b.substr(2, tagLen));
             if (!ret) break;
             b = b.substr(2 + tagLen);


### PR DESCRIPTION
prior to this there were no checks of length before accessing indices. this could be a reason for ub.