### PR TITLE
refactor: make NostrFilterGroup accept filters directly, add fromReq for REQ arrays

### DIFF
--- a/src/DBQuery.h
+++ b/src/DBQuery.h
@@ -296,7 +296,7 @@ struct DBQuery : NonCopyable {
     uint64_t totalWork = 0;
 
     DBQuery(Subscription &sub) : sub(std::move(sub)) {}
-    DBQuery(const tao::json::value &filter, uint64_t maxLimit = MAX_U64) : sub(Subscription(1, ".", NostrFilterGroup::unwrapped(filter, maxLimit))) {}
+    DBQuery(const tao::json::value &filter, uint64_t maxLimit = MAX_U64) : sub(Subscription(1, ".", NostrFilterGroup(filter, maxLimit))) {}
 
     // If scan is complete, returns true
     bool process(lmdb::txn &txn, const std::function<void(const Subscription &, uint64_t)> &cb, uint64_t timeBudgetMicroseconds = MAX_U64, bool logMetrics = false) {

--- a/src/apps/dbutils/cmd_monitor.cpp
+++ b/src/apps/dbutils/cmd_monitor.cpp
@@ -38,7 +38,7 @@ void cmd_monitor(const std::vector<std::string> &subArgs) {
         auto cmd = msgArr.at(0).get_string();
 
         if (cmd == "sub") {
-            Subscription sub(msgArr.at(1).get_unsigned(), msgArr.at(2).get_string(), NostrFilterGroup::unwrapped(msgArr.at(3)));
+            Subscription sub(msgArr.at(1).get_unsigned(), msgArr.at(2).get_string(), NostrFilterGroup(msgArr.at(3)));
             sub.latestEventId = 0;
             monitors.addSub(txn, std::move(sub), 0);
         } else if (cmd == "removeSub") {

--- a/src/apps/dbutils/cmd_negentropy.cpp
+++ b/src/apps/dbutils/cmd_negentropy.cpp
@@ -48,7 +48,7 @@ void cmd_negentropy(const std::vector<std::string> &subArgs) {
         std::string filterStr = args["<filter>"].asString();
 
         tao::json::value filterJson = tao::json::from_string(filterStr);
-        auto compiledFilter = NostrFilterGroup::unwrapped(filterJson);
+        auto compiledFilter = NostrFilterGroup(filterJson);
 
         if (compiledFilter.filters.size() == 1 && (compiledFilter.filters[0].since != 0 || compiledFilter.filters[0].until != MAX_U64)) {
             throw herr("single filters should not have since/until");

--- a/src/apps/mesh/cmd_router.cpp
+++ b/src/apps/mesh/cmd_router.cpp
@@ -104,7 +104,7 @@ struct Router {
                 if (newFilterStr != filterStr) needsReconnect = true;
 
                 filterStr = newFilterStr;
-                filterCompiled = NostrFilterGroup::unwrapped(newFilter);
+                filterCompiled = NostrFilterGroup(newFilter);
                 filter = newFilter;
             }
 

--- a/src/apps/mesh/cmd_sync.cpp
+++ b/src/apps/mesh/cmd_sync.cpp
@@ -70,7 +70,7 @@ void cmd_sync(const std::vector<std::string> &subArgs) {
     uint64_t timeout = 0;
     if (args["--timeout"]) timeout = args["--timeout"].asLong();
 
-    auto filterCompiled = NostrFilterGroup::unwrapped(filterJson);
+    auto filterCompiled = NostrFilterGroup(filterJson);
 
     std::optional<uint64_t> treeId;
     negentropy::storage::Vector storageVector;

--- a/src/apps/relay/RelayIngester.cpp
+++ b/src/apps/relay/RelayIngester.cpp
@@ -214,7 +214,7 @@ void RelayServer::ingesterProcessReq(lmdb::txn &txn, RelayServerCtx &rsctx, uint
         maxFilterLimit = cfg().relay__maxFilterLimit;
     }
 
-    NostrFilterGroup filterGroup(arr, maxFilterLimit);
+    NostrFilterGroup filterGroup = NostrFilterGroup::fromReq(arr, maxFilterLimit);
 
     try {
         rsctx.filterValidator.validate(filterGroup);
@@ -298,7 +298,7 @@ void RelayServer::ingesterProcessNegentropy(lmdb::txn &txn, uint64_t connId, con
         auto filterJson = arr.at(2);
         if (!filterJson.is_object()) throw herr("negentropy filter must be an object");
 
-        NostrFilterGroup filter = NostrFilterGroup::unwrapped(filterJson, maxFilterLimit);
+        NostrFilterGroup filter(filterJson, maxFilterLimit);
         Subscription sub(connId, subscriptionStr, std::move(filter));
 
         filterJson.get_object().erase("since");

--- a/src/filters.h
+++ b/src/filters.h
@@ -252,30 +252,29 @@ struct NostrFilterGroup {
 
     NostrFilterGroup() {}
 
-    // Note that this expects the full array, so the first two items are "REQ" and the subId
-    NostrFilterGroup(const tao::json::value &req, uint64_t maxFilterLimit = cfg().relay__maxFilterLimit) {
-        const auto &arr = req.get_array();
-        if (arr.size() < 3) throw herr("too small");
-
-        for (size_t i = 2; i < arr.size(); i++) {
-            filters.emplace_back(arr[i], maxFilterLimit);
-            if (filters.back().neverMatch) filters.pop_back();
-        }
-    }
-
-    // FIXME refactor: Make unwrapped the default constructor
-    static NostrFilterGroup unwrapped(tao::json::value filter, uint64_t maxFilterLimit = cfg().relay__maxFilterLimit) {
+    NostrFilterGroup(tao::json::value filter, uint64_t maxFilterLimit = cfg().relay__maxFilterLimit) {
         if (!filter.is_array()) {
             filter = tao::json::value::array({ filter });
         }
 
-        tao::json::value pretendReqQuery = tao::json::value::array({ "REQ", "junkSub" });
-
         for (auto &e : filter.get_array()) {
-            pretendReqQuery.push_back(e);
+            filters.emplace_back(e, maxFilterLimit);
+            if (filters.back().neverMatch) filters.pop_back();
+        }
+    }
+
+    static NostrFilterGroup fromReq(const tao::json::value &req, uint64_t maxFilterLimit = cfg().relay__maxFilterLimit) {
+        const auto &arr = req.get_array();
+        if (arr.size() < 3) throw herr("too small");
+
+        NostrFilterGroup fg;
+
+        for (size_t i = 2; i < arr.size(); i++) {
+            fg.filters.emplace_back(arr[i], maxFilterLimit);
+            if (fg.filters.back().neverMatch) fg.filters.pop_back();
         }
 
-        return NostrFilterGroup(pretendReqQuery, maxFilterLimit);
+        return fg;
     }
 
     bool doesMatch(PackedEventView ev) const {


### PR DESCRIPTION
## Description
The FIXME at line 266 notes that `NostrFilterGroup::unwrapped()` should be the default constructor. Currently, the main constructor expects a full REQ message array (`["REQ", "subId", {filter}, ...]`) and callers that just have filter objects must go through the `unwrapped()` static factory — which internally builds a fake REQ array wrapper to call the same constructor.

This refactoring:
1. Makes the primary constructor accept filter objects directly (single object or array of objects).
2. Moves the REQ-array parsing into a new `fromReq()` static method — used only by `RelayIngester` when parsing actual client REQ messages.
3. Removes the `unwrapped()` static method.

## Issue
- FIXME in `src/filters.h` file on line number 266

## Testing
- The application builds and runs as expected