### PR TITLE
feat: Add proper MacOS support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,10 +18,6 @@ jobs:
           brew install pkg-config libtool openssl zlib lmdb flatbuffers secp256k1 zstd libuv perl
 
       - name: Build strfry
-        env:
-          PKG_CONFIG_PATH: /opt/homebrew/opt/openssl/lib/pkgconfig
-          LDFLAGS: -L/opt/homebrew/lib
-          CPPFLAGS: -I/opt/homebrew/include
         run: |
           git submodule update --init
           make setup-golpe

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,40 @@
+name: macos
+
+on: [push, pull_request]
+
+jobs:
+  macos:
+    runs-on: macos-latest
+    name: A job to build and run strfry on macOS
+    steps:
+      - name: Checkout strfry
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install pkg-config libtool openssl zlib lmdb flatbuffers secp256k1 zstd libuv perl
+
+      - name: Build strfry
+        env:
+          PKG_CONFIG_PATH: /opt/homebrew/opt/openssl/lib/pkgconfig
+          LDFLAGS: -L/opt/homebrew/lib
+          CPPFLAGS: -I/opt/homebrew/include
+        run: |
+          git submodule update --init
+          make setup-golpe
+          make -j4
+          if ! [ -f ./strfry ]; then
+             echo "Strfry build failed."
+             exit 1
+          fi
+
+      - name: Run strfry
+        run: |
+          sw_vers
+          mkdir -p strfry-db
+          ./strfry relay &
+          sleep 2
+          kill %1 || true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           git submodule update --init
           make setup-golpe
-          make -j4
+          make -j$(nproc)
           if ! [ -f ./strfry ]; then
              echo "Strfry build failed."
              exit 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,11 +26,3 @@ jobs:
              echo "Strfry build failed."
              exit 1
           fi
-
-      - name: Run strfry
-        run: |
-          sw_vers
-          mkdir -p strfry-db
-          ./strfry relay &
-          sleep 2
-          kill %1 || true

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,15 @@
 name: macos
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+    paths-ignore: [ '**.md', 'docs/**' ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   macos:
@@ -21,7 +30,7 @@ jobs:
         run: |
           git submodule update --init
           make setup-golpe
-          make -j$(nproc)
+          make -j$(sysctl -n hw.logicalcpu)
           if ! [ -f ./strfry ]; then
              echo "Strfry build failed."
              exit 1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,7 +8,7 @@ jobs:
     name: A job to build and run strfry on macOS
     steps:
       - name: Checkout strfry
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -17,7 +17,7 @@ jobs:
     name: A job to build and run strfry on Ubuntu
     steps:
       - name: Checkout strfry
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ include golpe/rules.mk
 LDLIBS += -lsecp256k1 -lzstd
 ifeq ($(shell uname -s),Darwin)
 LDLIBS += -luv
+BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+ifneq ($(BREW_PREFIX),)
+INCS    += -I$(BREW_PREFIX)/include -I$(BREW_PREFIX)/opt/openssl/include
+LDFLAGS += -L$(BREW_PREFIX)/lib -L$(BREW_PREFIX)/opt/openssl/lib
+endif
 endif
 INCS += -Iexternal/negentropy/cpp
 

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,18 @@ LDLIBS += -luv
 BREW_PREFIX    := $(shell brew --prefix 2>/dev/null)
 OPENSSL_PREFIX := $(shell brew --prefix openssl 2>/dev/null)
 ifneq ($(BREW_PREFIX),)
-INCS    += -I$(BREW_PREFIX)/include
-LDFLAGS += -L$(BREW_PREFIX)/lib
+BREW_INCS += -I$(BREW_PREFIX)/include
+BREW_LIBS += -L$(BREW_PREFIX)/lib
 endif
 ifneq ($(OPENSSL_PREFIX),)
-INCS    += -I$(OPENSSL_PREFIX)/include
-LDFLAGS += -L$(OPENSSL_PREFIX)/lib
+BREW_INCS += -I$(OPENSSL_PREFIX)/include
+BREW_LIBS += -L$(OPENSSL_PREFIX)/lib
 endif
+INCS      += $(BREW_INCS)
+LDFLAGS   += $(BREW_LIBS)
+# Propagate to sub-makes (e.g. uWebSockets) that honor XCXXFLAGS / XLDFLAGS
+export XCXXFLAGS += $(BREW_INCS)
+export XLDFLAGS  += $(BREW_LIBS)
 endif
 INCS += -Iexternal/negentropy/cpp
 

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ OPT  ?= -O3 -g
 include golpe/rules.mk
 
 LDLIBS += -lsecp256k1 -lzstd
+ifeq ($(shell uname -s),Darwin)
+LDLIBS += -luv
+endif
 INCS += -Iexternal/negentropy/cpp
 
 build/StrfryTemplates.h: $(shell find src/tmpls/ -type f -name '*.tmpl')

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,15 @@ include golpe/rules.mk
 LDLIBS += -lsecp256k1 -lzstd
 ifeq ($(shell uname -s),Darwin)
 LDLIBS += -luv
-BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
+BREW_PREFIX    := $(shell brew --prefix 2>/dev/null)
+OPENSSL_PREFIX := $(shell brew --prefix openssl 2>/dev/null)
 ifneq ($(BREW_PREFIX),)
-INCS    += -I$(BREW_PREFIX)/include -I$(BREW_PREFIX)/opt/openssl/include
-LDFLAGS += -L$(BREW_PREFIX)/lib -L$(BREW_PREFIX)/opt/openssl/lib
+INCS    += -I$(BREW_PREFIX)/include
+LDFLAGS += -L$(BREW_PREFIX)/lib
+endif
+ifneq ($(OPENSSL_PREFIX),)
+INCS    += -I$(OPENSSL_PREFIX)/include
+LDFLAGS += -L$(OPENSSL_PREFIX)/lib
 endif
 endif
 INCS += -Iexternal/negentropy/cpp

--- a/src/PluginEventSifter.h
+++ b/src/PluginEventSifter.h
@@ -12,14 +12,21 @@
 
 #include <memory>
 
+#ifdef __APPLE__
+#define st_mtim st_mtimespec
+#endif
+
 #include "hoytech/stream.h"
 
 #include "golpe.h"
 
 #include "events.h"
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__)
 extern char **environ;
+#elif defined(__APPLE__)
+#include <crt_externs.h>
+#define environ (*_NSGetEnviron())
 #endif
 
 

--- a/src/PluginEventSifter.h
+++ b/src/PluginEventSifter.h
@@ -12,7 +12,7 @@
 
 #include <memory>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 #define st_mtim st_mtimespec
 #endif
 
@@ -22,7 +22,7 @@
 
 #include "events.h"
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 extern char **environ;
 #elif defined(__APPLE__)
 #include <crt_externs.h>


### PR DESCRIPTION
## Description
strfry currently only builds on Linux. This PR makes it build and run on macOS and adds a GitHub Actions workflow to keep it that way.

## Issue
- fixes #189 

## Depends On
- [hoytech-cpp #1](https://github.com/hoytech/hoytech-cpp/pull/1)
- [session-token-cpp #1](https://github.com/hoytech/session-token-cpp/pull/1) 
- After the above 2 get merged and the submodules get bumped in strfry, it will be fully ready to get merged

## Testing
- Please refer to [hoytech-cpp #1](https://github.com/hoytech/hoytech-cpp/pull/1) as I have added all the relevant screenshots there of both Linux and MacOS