### PR TITLE
docs: add Community Integrations section for Namecoin identity projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If you are using strfry, please [join our telegram chat](https://t.me/strfry_use
     * [Syncing](#syncing)
     * [Compression Dictionaries](#compression-dictionaries)
 * [Learn More](#learn-more)
+* [Community Integrations](#community-integrations)
 * [Author and Copyright](#author-and-copyright)
 
 <!-- END OF TOC -->
@@ -372,6 +373,20 @@ For details on strfry's architecture, see the [architecture.md](https://github.c
 To report issues or submit pull requests, please visit the [strfry github page](https://github.com/hoytech/strfry).
 
 To chat with the strfry devs and community, please [join our telegram chat](https://t.me/strfry_users).
+
+
+
+## Community Integrations
+
+These are third-party projects built around strfry. They are not maintained by the strfry authors.
+
+**Namecoin identity**
+
+* [strfry-namecoin-policy](https://github.com/mstrofnone/strfry-namecoin-policy) - write-policy plugin that verifies `.bit` [NIP-05](https://github.com/nostr-protocol/nips/blob/master/05.md) identities against the Namecoin blockchain via ElectrumX, so the relay only accepts `kind:0` events whose claimed `.bit` identity is backed on-chain.
+* [strfry-nip05-namecoin](https://github.com/mstrofnone/strfry-nip05-namecoin) - HTTP sidecar that serves `/.well-known/nostr.json` from Namecoin `.bit` records, letting conventional NIP-05 clients verify `.bit`-backed identities with no Namecoin-specific support.
+* [namecoin-nostr-bridge](https://github.com/mstrofnone/namecoin-nostr-bridge) - daemon that republishes Namecoin `d/*` identity records as Nostr events, turning the Namecoin chain into a Nostr-queryable identity index.
+
+If you know of other integrations worth listing here, please open a PR.
 
 
 


### PR DESCRIPTION
This is a small docs-only change that adds a "Community Integrations" section near the bottom of `README.md` (with a matching TOC entry), listing three third-party projects that wire Namecoin-based identity into strfry:

- [strfry-namecoin-policy](https://github.com/mstrofnone/strfry-namecoin-policy) — write-policy plugin that verifies `.bit` NIP-05 identities via ElectrumX.
- [strfry-nip05-namecoin](https://github.com/mstrofnone/strfry-nip05-namecoin) — HTTP sidecar serving NIP-05 `/.well-known/nostr.json` from Namecoin records.
- [namecoin-nostr-bridge](https://github.com/mstrofnone/namecoin-nostr-bridge) — daemon that republishes on-chain Namecoin identity records as Nostr events.

The section explicitly notes these are third-party projects not maintained by the strfry authors, and invites further community integration PRs.

No code, build, or config changes — only `README.md` (15 lines added, 0 removed).

Note: the three linked repos are being published in parallel with this PR and may briefly 404; they should all be live within a few hours. Happy to adjust wording, move the section to `docs/plugins.md`, or drop it entirely if you'd prefer not to carry third-party links in the main README. Thanks for strfry!
