### PR TITLE
Feature: Per-connection pending outbound observability and configurable back-pressure cap

### DIFF
--- a/src/PrometheusMetrics.h
+++ b/src/PrometheusMetrics.h
@@ -107,6 +107,7 @@ public:
 
     // Connection tracking
     Gauge activeConnections;
+    Counter slowClientTerminations;
 
     // Generate Prometheus text format output
     std::string render() const {
@@ -161,6 +162,10 @@ public:
         out << "# HELP strfry_connections_current Current number of active WebSocket connections\n";
         out << "# TYPE strfry_connections_current gauge\n";
         out << "strfry_connections_current " << activeConnections.get() << "\n";
+
+        out << "# HELP strfry_slow_client_terminations_total Connections closed for exceeding relay.maxPendingOutboundBytes\n";
+        out << "# TYPE strfry_slow_client_terminations_total counter\n";
+        out << "strfry_slow_client_terminations_total " << slowClientTerminations.get() << "\n";
 
         return out.str();
     }

--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -369,6 +369,23 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
                               true, &compressedSize);
             c.stats.bytesUp += payloadSize;
             c.stats.bytesUpCompressed += compressedSize;
+
+            // Back-pressure: if a client is too slow to read and the outbound
+            // backlog inside uWS exceeds the configured cap, drop the connection
+            // to bound memory. terminate() synchronously invokes our
+            // onDisconnection (which logs and deletes the Connection) and then
+            // drains the queued sends with cancellation callbacks, so no queue
+            // entries leak. c is dangling after terminate(), so we must return.
+            const uint64_t maxPending = cfg().relay__maxPendingOutboundBytes;
+            if (maxPending > 0 && c.stats.pendingOutbound > maxPending) {
+                LW << "[" << c.connId << "] Slow client: pendingOutbound "
+                   << renderSize(c.stats.pendingOutbound)
+                   << " exceeds relay.maxPendingOutboundBytes "
+                   << renderSize(maxPending) << ", terminating";
+                PrometheusMetrics::getInstance().slowClientTerminations.inc();
+                c.websocket->terminate();
+                return;
+            }
         };
 
         for (auto &newMsg : newMsgs) {

--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -82,6 +82,9 @@ config:
   - name: relay__maxSubsPerConnection
     desc: "Maximum number of subscriptions (concurrent REQs) a connection can have open at any time"
     default: 200
+  - name: relay__maxPendingOutboundBytes
+    desc: "Per-connection cap on unsent outbound bytes buffered inside the websocket library (0 = unlimited). Connections exceeding this are terminated to bound memory used by slow/stalled clients."
+    default: 0
 
   - name: relay__writePolicy__plugin
     desc: "If non-empty, path to an executable script that implements the writePolicy plugin logic"

--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -83,8 +83,8 @@ config:
     desc: "Maximum number of subscriptions (concurrent REQs) a connection can have open at any time"
     default: 200
   - name: relay__maxPendingOutboundBytes
-    desc: "Per-connection cap on unsent outbound bytes buffered inside the websocket library (0 = unlimited). Connections exceeding this are terminated to bound memory used by slow/stalled clients."
-    default: 0
+    desc: "Per-connection cap on unsent outbound bytes buffered inside the websocket library (0 = unlimited). Default 33554432 (32 MiB) aligns with worst-case outbound for one maximal filter under default maxFilterLimit × maxEventSize. Connections exceeding this are terminated to bound memory used by slow/stalled clients."
+    default: 33554432
 
   - name: relay__writePolicy__plugin
     desc: "If non-empty, path to an executable script that implements the writePolicy plugin logic"

--- a/strfry.conf
+++ b/strfry.conf
@@ -120,8 +120,9 @@ relay {
     maxSubsPerConnection = 200
 
     # Per-connection cap on unsent outbound bytes buffered inside the websocket library (0 = unlimited).
+    # Default matches worst-case outbound for one maximal filter under default maxFilterLimit × maxEventSize (~32 MiB).
     # Connections exceeding this are terminated to bound memory used by slow/stalled clients.
-    maxPendingOutboundBytes = 0
+    maxPendingOutboundBytes = 33554432
 
     writePolicy {
         # If non-empty, path to an executable script that implements the writePolicy plugin logic

--- a/strfry.conf
+++ b/strfry.conf
@@ -119,6 +119,10 @@ relay {
     # Maximum number of subscriptions (concurrent REQs) a connection can have open at any time
     maxSubsPerConnection = 200
 
+    # Per-connection cap on unsent outbound bytes buffered inside the websocket library (0 = unlimited).
+    # Connections exceeding this are terminated to bound memory used by slow/stalled clients.
+    maxPendingOutboundBytes = 0
+
     writePolicy {
         # If non-empty, path to an executable script that implements the writePolicy plugin logic
         plugin = ""


### PR DESCRIPTION
## Description

### Observability (#212) — `src/apps/relay/RelayWebsocket.cpp`

- Extends `Connection::Stats` with **`pendingOutbound`**: application bytes passed to `WebSocket::send` that are not yet fully drained (still in uWS’s queue or an in-flight partial write).
- In **`doSend`**, increments `pendingOutbound` by `payload.size()` immediately before `send()`, passes that size through the send completion callback’s user-data pointer (`uintptr_t` via `void *`), and decrements in the callback when uWS reports the message finished (success, immediate failure, or after queued drain).
- The completion callback returns early when **`ws == nullptr`**, matching uWS’s `onEnd` flush path: that can run after `onDisconnection` has logged and deleted the `Connection`, so we must not dereference `getUserData()` there. The disconnect log therefore captures whatever `pendingOutbound` was at teardown time; post-disconnect cancellation callbacks do not touch freed memory.
- Extends the existing disconnect log line (UP/DN bytes and compression) with **`Pending: …`** using the same `renderSize` helper.
- **No change** to *when* or *what* is sent for the observability path alone; the cap below is optional and off by default.

### Back-pressure cap — `src/apps/relay/RelayWebsocket.cpp`, `src/apps/relay/golpe.yaml`, `strfry.conf`, `src/PrometheusMetrics.h`

- New config **`relay.maxPendingOutboundBytes`** (`relay__maxPendingOutboundBytes` / `--set relay__maxPendingOutboundBytes=…`), **default `0` = unlimited** (backward compatible).
- After each `send()` in `doSend`, if the cap is non-zero and **`pendingOutbound` exceeds the threshold**, the relay logs a warning and calls **`websocket->terminate()`**, then returns immediately (`Connection` is freed synchronously in `onDisconnection`; `c` must not be used after `terminate()`).
- **`terminate()`** is used instead of **`close()`** so we do not enqueue an extra CLOSE frame on an already backlogged outbound path.
- Adds Prometheus counter **`strfry_slow_client_terminations_total`** for operators who scrape `/metrics`.
- Does **not** patch uWebSockets, does **not** change `ReqMonitor` flow control, and does **not** pace upstream producers beyond dropping the slow peer.

### Related issues

- **Closes #213** 

---

## Motivation and context

Slow or stalled readers can leave a large amount of application payload buffered inside uWS. Operators previously saw aggregate UP bytes on disconnect but not how much was still queued. **`pendingOutbound`** makes that visible per connection. The optional cap bounds memory by terminating peers that fall too far behind, without claiming full TCP buffer accounting.

---

## How has this been tested?

**Environment:** Local build (WSL/Linux with the existing strfry toolchain per README).

**Commands run:**

- `make setup-golpe && make -j4` (or project-equivalent full relay build).
- **Manual smoke (observability):** `./strfry relay` → WebSocket client connect → REQ path that receives outbound frames → clean close; confirm disconnect log includes **`Pending:`** (often **`0b`** when the queue has drained before close).
- **Manual smoke (cap):** populate a small DB (e.g. `strfry import --no-verify` with many medium-sized events), start relay with `--set relay__maxPendingOutboundBytes=<low value>`, connect a client that performs the WebSocket handshake then sends many REQs and **does not read** (small `SO_RCVBUF` helps); confirm log line **`Slow client: pendingOutbound … exceeds relay.maxPendingOutboundBytes`** and **`strfry_slow_client_terminations_total`** on `/metrics`. 



**Screenshots:** N/A

---

## Types of changes

- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Default **`maxPendingOutboundBytes = 0`** preserves prior behavior except for the extra **`Pending:`** field in the disconnect log.

---

## Checklist

- [x] My code follows the code style of this project.
- [ ] I have updated the TODO accordingly. 
- [x] All new and existing tests passed 