### PR TITLE
refactor(negentropy): split negentropy build into read-only and write txn phases

### DIFF
--- a/src/apps/dbutils/cmd_negentropy.cpp
+++ b/src/apps/dbutils/cmd_negentropy.cpp
@@ -80,44 +80,46 @@ void cmd_negentropy(const std::vector<std::string> &subArgs) {
 
         std::vector<Record> recs;
 
-        auto txn = env.txn_rw(); // FIXME: split this into a read-only phase followed by a write
-        increaseModCounter(txn);
-
-        // Get filter
-
-        std::string filterStr;
-
+        // Read-only phase: fetch filter and collect matching events without
+        // blocking writers.
         {
-            auto view = env.lookup_NegentropyFilter(txn, treeId);
-            if (!view) throw herr("couldn't find treeId: ", treeId);
-            filterStr = view->filter();
+            auto txn = env.txn_ro();
+
+            std::string filterStr;
+
+            {
+                auto view = env.lookup_NegentropyFilter(txn, treeId);
+                if (!view) throw herr("couldn't find treeId: ", treeId);
+                filterStr = view->filter();
+            }
+
+            DBQuery query(tao::json::from_string(filterStr));
+
+            while (1) {
+                bool complete = query.process(txn, [&](const auto &sub, uint64_t levId){
+                    auto ev = lookupEventByLevId(txn, levId);
+                    auto packed = PackedEventView(ev.buf);
+                    recs.emplace_back(packed.created_at(), packed.id());
+                });
+
+                if (complete) break;
+            }
         }
 
-        // Query all matching events
+        // Write phase: store collected records into the negentropy BTree.
+        {
+            auto txn = env.txn_rw();
+            increaseModCounter(txn);
 
-        DBQuery query(tao::json::from_string(filterStr));
+            negentropy::storage::BTreeLMDB storage(txn, negentropyDbi, treeId);
 
-        while (1) {
-            bool complete = query.process(txn, [&](const auto &sub, uint64_t levId){
-                auto ev = lookupEventByLevId(txn, levId);
-                auto packed = PackedEventView(ev.buf);
-                recs.emplace_back(packed.created_at(), packed.id());
-                //memcpy(recs.back().id, packed.id().data(), 32);
-            });
+            for (const auto &r : recs) {
+                storage.insert(r.created_at, r.id.sv());
+            }
 
-            if (complete) break;
+            storage.flush();
+
+            txn.commit();
         }
-
-        // Store events in negentropy tree
-
-        negentropy::storage::BTreeLMDB storage(txn, negentropyDbi, treeId);
-
-        for (const auto &r : recs) {
-            storage.insert(r.created_at, r.id.sv());
-        }
-
-        storage.flush();
-
-        txn.commit();
     }
 }


### PR DESCRIPTION
### Issue
- FIXME at `src/apps/dbutils/cmd_negentropy.cpp:83

### Description

The `negentropy build` subcommand currently opens a single read-write transaction (`txn_rw()`) that spans both the event scan and the BTree storage write. On large databases, the scan can take a long time — and during that entire window, all other writers (event ingestion, deletions, etc.) are blocked because LMDB only allows one writer at a time.

This splits the operation into two phases:
1. **Read-only phase** (`txn_ro()`): fetch the filter and scan all matching events, collecting `(created_at, id)` pairs into a vector.
2. **Write phase** (`txn_rw()`): increment the modification counter and insert the collected records into the BTree.

The write transaction is now held only for the short insertion step.