### PR TITLE
fix(subscription): move-construct NostrFilterGroup instead of copying

### DIFF
--- a/src/Subscription.h
+++ b/src/Subscription.h
@@ -47,7 +47,7 @@ namespace std {
 
 struct Subscription : NonCopyable {
     Subscription(uint64_t connId_, const std::string &subId_, NostrFilterGroup filterGroup_, bool countOnly_ = false)
-        : connId(connId_), subId(subId_), filterGroup(filterGroup_), countOnly(countOnly_) {}
+        : connId(connId_), subId(subId_), filterGroup(std::move(filterGroup_)), countOnly(countOnly_) {}
 
     // Params
 


### PR DESCRIPTION
## Description

In src/Subscription.h the Subscription ctor takes NostrFilterGroup filterGroup_ by value (move-constructed from the caller), but then initializes the member with filterGroup(filterGroup_) — an lvalue, so it's a copy of every filter, filter-set byte buffer, and flat_hash_map<char, FilterSetBytes>. Every REQ / NEG-OPEN dispatched through the ingester → reqWorker / negentropy thread pool pays for this copy.