### PR TITLE
perf(monitors): remove std::function heap allocs and use direct map find in pub-sub fanout

### DIFF
--- a/src/ActiveMonitors.h
+++ b/src/ActiveMonitors.h
@@ -101,49 +101,25 @@ struct ActiveMonitors : NonCopyable {
             }
         };
 
-        auto processMonitorsExact = [&]<typename T>(btree_map<T, MonitorSet> &m, const T &key, const std::function<bool(const T &)> &matches){
-            auto it = m.upper_bound(key);
-
-            if (it == m.begin()) return;
-            it = std::prev(it);
-
-            while (matches(it->first)) {
-                processMonitorSet(it->second);
-                if (it == m.begin()) break;
-                it = std::prev(it);
-            }
+        // Exact-key lookup only: installLookups keys monitors by id / author / tagSpec /
+        // kind string. Prior code used upper_bound + prev + equality predicate; with
+        // unique btree keys that is equivalent to find() without std::function per call.
+        auto lookupMonitors = [&]<typename T>(btree_map<T, MonitorSet> &m, const T &key) {
+            auto it = m.find(key);
+            if (it != m.end()) processMonitorSet(it->second);
         };
 
         auto packed = PackedEventView(ev.buf);
 
-        {
-            Bytes32 id(packed.id());
-            processMonitorsExact(allIds, id, static_cast<const std::function<bool(const Bytes32&)> &>([&](const Bytes32 &val){
-                return id == val;
-            }));
-        }
-
-        {
-            Bytes32 pubkey(packed.pubkey());
-            processMonitorsExact(allAuthors, pubkey, static_cast<const std::function<bool(const Bytes32&)> &>([&](const Bytes32 &val){
-                return pubkey == val;
-            }));
-        }
+        lookupMonitors(allIds, Bytes32(packed.id()));
+        lookupMonitors(allAuthors, Bytes32(packed.pubkey()));
 
         packed.foreachTag([&](char tagName, std::string_view tagVal){
-            auto &tagSpec = getTagSpec(tagName, tagVal);
-            processMonitorsExact(allTags, tagSpec, static_cast<const std::function<bool(const std::string&)> &>([&](const std::string &val){
-                return tagSpec == val;
-            }));
+            lookupMonitors(allTags, getTagSpec(tagName, tagVal));
             return true;
         });
 
-        {
-            auto kind = packed.kind();
-            processMonitorsExact(allKinds, kind, static_cast<const std::function<bool(const uint64_t&)> &>([&](const uint64_t &val){
-                return kind == val;
-            }));
-        }
+        lookupMonitors(allKinds, packed.kind());
 
         processMonitorSet(allOthers);
 


### PR DESCRIPTION
### Description

`ActiveMonitors::process` runs for every new event that is applied to live subscriptions. It previously looked up candidate monitor sets with `upper_bound` + `prev` + a `while` loop and a **`std::function<bool(const T&)>`** built from a lambda for each of id, author, each tag, and kind.

Monitor indexes are installed with **one `btree_map` entry per exact key** (event id, author pubkey, tag spec string, kind). Keys are unique, and every call site only ever used an **equality** predicate (`id == val`, etc.). For such a map, the only matching node is **`m.find(key)`**; the old walk could touch at most that same entry.

This change replaces that path with a small templated **`lookupMonitors`** helper that calls **`find`** and processes the `MonitorSet` when present. It removes **per-event `std::function` construction** (and associated type erasure / allocation behavior) and simplifies the lookup logic with no change to which monitors are considered.

**Files:** `src/ActiveMonitors.h`

### Motivation and context

Live subscription fanout is on the hot path when the relay is under write load. Fewer temporary objects and a direct map lookup improve CPU and allocator pressure under realistic workloads, without changing Nostr semantics.

### How has this been tested?

- `make -j4` (full tree)
- Existing relay / subscription behavior unchanged by construction (same keys, same `processMonitorSet` body); no new tests added.
- script automated testing

### Types of changes

- [ ] Non-functional change (docs, style, minor refactor)
- [ ] Bug fix
- [x] New feature / improvement *(performance)*
- [ ] Breaking change

### Checklist

- [x] Matches project style
- [x] Build passes locally
