### PR TITLE
fix(metrics): count nostr_events_total on successful DB write, not on ingress

### DIFF
--- a/src/PrometheusMetrics.h
+++ b/src/PrometheusMetrics.h
@@ -128,8 +128,8 @@ public:
             out << "nostr_relay_messages_total{verb=\"" << verb << "\"} " << count << "\n";
         }
         
-        // Events by kind
-        out << "# HELP nostr_events_total Total number of Nostr events by kind\n";
+        // Events by kind (incremented when an event is persisted as Written, not on ingress)
+        out << "# HELP nostr_events_total Total number of Nostr events persisted to the DB, by kind\n";
         out << "# TYPE nostr_events_total counter\n";
         auto events = nostrEventsByKind.getAll();
         for (const auto& [kind, count] : events) {

--- a/src/apps/relay/RelayIngester.cpp
+++ b/src/apps/relay/RelayIngester.cpp
@@ -112,9 +112,6 @@ void RelayServer::ingesterProcessEvent(lmdb::txn &txn, RelayServerCtx &rsctx, ui
 
     PackedEventView packed(packedStr);
     Bytes32 authedPubkey;
-    
-    // Track event kind metrics
-    PROM_INC_EVENT_KIND(std::to_string(packed.kind()));
 
     {
         // discard reposts that embed protected events

--- a/src/apps/relay/RelayWriter.cpp
+++ b/src/apps/relay/RelayWriter.cpp
@@ -99,6 +99,7 @@ void RelayServer::runWriter(ThreadPool<MsgWriter>::Thread &thr) {
                 LI << "Inserted event. id=" << eventIdHex << " levId=" << newEvent.levId;
                 written = true;
                 PrometheusMetrics::getInstance().writtenEventsTotal.inc();
+                PROM_INC_EVENT_KIND(std::to_string(packed.kind()));
             } else if (newEvent.status == EventWriteStatus::Duplicate) {
                 message = "duplicate: have this event";
                 written = true;


### PR DESCRIPTION
### Description
`nostr_events_total{kind="…"}` was incremented in **`ingesterProcessEvent`** immediately after parse/verify, **before** duplicate detection, write-policy plugin, and the writer pipeline. That counted **every accepted parse** toward kind totals, including events that never became **`EventWriteStatus::Written`** (duplicates, plugin rejects, replace/delete outcomes, etc.).

This PR:

- **Removes** `PROM_INC_EVENT_KIND` from `src/apps/relay/RelayIngester.cpp`.
- **Adds** `PROM_INC_EVENT_KIND(std::to_string(packed.kind()))` in `src/apps/relay/RelayWriter.cpp` only when `newEvent.status == EventWriteStatus::Written`, alongside `writtenEventsTotal.inc()`.
- Updates the Prometheus **`# HELP nostr_events_total`** text in `src/PrometheusMetrics.h` to state that the counter reflects **events persisted to the DB**, not raw client ingress.

**Files:** `src/apps/relay/RelayIngester.cpp`, `src/apps/relay/RelayWriter.cpp`, `src/PrometheusMetrics.h`

### Motivation and context

Operators using Prometheus to reason about **stored** traffic and kind mix should not inflate totals with duplicates and write-path rejects. Counting at **Written** matches that intent.

### Types of changes

- [ ] Non-functional change
- [x] Bug fix 
- [x] Breaking change
- [ ] Breaking change

### Checklist

- [x] HELP text updated
- [x] Build passes locally

