### PR TITLE
Fix: add endian byte-swap for portable --fried import/export

### DIFF
--- a/src/PackedEvent.h
+++ b/src/PackedEvent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <bit>
+#include <cstring>
 #include <string_view>
 
 #include "golpe.h"
@@ -17,6 +19,36 @@
 //   0: tag char (1)
 //   1: length (1)
 //   2: value (variable)
+
+// Fixed-header layout used by the --fried import/export byte-swapper below.
+static constexpr size_t PACKED_EVENT_HEADER_SIZE    = 88;
+static constexpr size_t PACKED_EVENT_CREATED_AT_OFF = 64;
+static constexpr size_t PACKED_EVENT_KIND_OFF       = 72;
+static constexpr size_t PACKED_EVENT_EXPIRATION_OFF = 80;
+
+// Byte-swap the three uint64_t fields (created_at, kind, expiration) in the
+// fixed header of a packed event between native byte order and little-endian.
+// The --fried wire format is defined as always little-endian, so callers on
+// big-endian systems invoke this to serialise/deserialise.
+//
+// On little-endian hosts this is a compile-time no-op (the whole body is
+// discarded by `if constexpr`), giving zero runtime cost on x86/ARM-LE.
+//
+// Callers must ensure `packed.size() >= PACKED_EVENT_HEADER_SIZE` before
+// invoking this — untrusted input (e.g. hex-decoded from an imported file)
+// may be shorter.
+inline void friedSwapEndianInPlace(std::string &packed) {
+    if constexpr (std::endian::native != std::endian::little) {
+        for (size_t offset : {PACKED_EVENT_CREATED_AT_OFF, PACKED_EVENT_KIND_OFF, PACKED_EVENT_EXPIRATION_OFF}) {
+            uint64_t val;
+            std::memcpy(&val, packed.data() + offset, 8);
+            val = __builtin_bswap64(val);
+            std::memcpy(packed.data() + offset, &val, 8);
+        }
+    } else {
+        (void)packed;
+    }
+}
 
 struct PackedEventView {
     std::string_view buf;

--- a/src/apps/dbutils/cmd_export.cpp
+++ b/src/apps/dbutils/cmd_export.cpp
@@ -5,18 +5,7 @@
 #include "golpe.h"
 
 #include "events.h"
-
-
-static void friedSwapEndian(std::string &packed) {
-    if constexpr (std::endian::native != std::endian::little) {
-        for (size_t offset : {64, 72, 80}) {
-            uint64_t val;
-            std::memcpy(&val, packed.data() + offset, 8);
-            val = __builtin_bswap64(val);
-            std::memcpy(packed.data() + offset, &val, 8);
-        }
-    }
-}
+#include "PackedEvent.h"
 
 
 static const char USAGE[] =
@@ -67,7 +56,8 @@ void cmd_export(const std::vector<std::string> &subArgs) {
         if (fried) {
             auto ev = lookupEventByLevId(txn, levId);
             std::string packed(ev.buf);
-            friedSwapEndian(packed);
+            // Events produced by strfry always have the full fixed header; no bounds check needed on export path.
+            friedSwapEndianInPlace(packed);
 
             o.clear();
             o.reserve(json.size() + packed.size() * 2 + 100);

--- a/src/apps/dbutils/cmd_export.cpp
+++ b/src/apps/dbutils/cmd_export.cpp
@@ -1,9 +1,22 @@
 #include <iostream>
+#include <cstring>
 
 #include <docopt.h>
 #include "golpe.h"
 
 #include "events.h"
+
+
+static void friedSwapEndian(std::string &packed) {
+    if constexpr (std::endian::native != std::endian::little) {
+        for (size_t offset : {64, 72, 80}) {
+            uint64_t val;
+            std::memcpy(&val, packed.data() + offset, 8);
+            val = __builtin_bswap64(val);
+            std::memcpy(packed.data() + offset, &val, 8);
+        }
+    }
+}
 
 
 static const char USAGE[] =
@@ -31,7 +44,6 @@ void cmd_export(const std::vector<std::string> &subArgs) {
     if (dbVersion == 0) throw herr("migration from DB version 0 not supported by this version of strfry");
 
     if (fried) {
-        if (std::endian::native != std::endian::little) throw herr("--fried currently only supported on little-endian CPUs"); // FIXME
         if (dbVersion < 3) throw herr("can't export old DB version with --fried: please downgrade to 0.9.7");
     }
 
@@ -54,13 +66,15 @@ void cmd_export(const std::vector<std::string> &subArgs) {
 
         if (fried) {
             auto ev = lookupEventByLevId(txn, levId);
+            std::string packed(ev.buf);
+            friedSwapEndian(packed);
 
             o.clear();
-            o.reserve(json.size() + ev.buf.size() * 2 + 100);
+            o.reserve(json.size() + packed.size() * 2 + 100);
             o = json;
             o.resize(o.size() - 1);
             o += ",\"fried\":\"";
-            o += to_hex(ev.buf);
+            o += to_hex(packed);
             o += "\"}\n";
 
             std::cout << o;

--- a/src/apps/dbutils/cmd_import.cpp
+++ b/src/apps/dbutils/cmd_import.cpp
@@ -7,19 +7,8 @@
 #include <docopt.h>
 #include "golpe.h"
 
+#include "PackedEvent.h"
 #include "WriterPipeline.h"
-
-
-static void friedSwapEndian(std::string &packed) {
-    if constexpr (std::endian::native != std::endian::little) {
-        for (size_t offset : {64, 72, 80}) {
-            uint64_t val;
-            std::memcpy(&val, packed.data() + offset, 8);
-            val = __builtin_bswap64(val);
-            std::memcpy(packed.data() + offset, &val, 8);
-        }
-    }
-}
 
 
 static const char USAGE[] =
@@ -42,7 +31,8 @@ EventToWrite parseFried(std::string_view lineSv) {
     if (!std::string_view(line).substr(0, i + 1).ends_with(",\"fried\":\"")) throw herr("fried parse error");
 
     std::string packed = from_hex(std::string_view(line).substr(i + 1, line.size() - i - 3));
-    friedSwapEndian(packed);
+    if (packed.size() < PACKED_EVENT_HEADER_SIZE) throw herr("fried packed too short");
+    friedSwapEndianInPlace(packed);
 
     line[i - 9] = '}';
     line.resize(i - 8);

--- a/src/apps/dbutils/cmd_import.cpp
+++ b/src/apps/dbutils/cmd_import.cpp
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <cstring>
 
 #include <iostream>
 
@@ -7,6 +8,18 @@
 #include "golpe.h"
 
 #include "WriterPipeline.h"
+
+
+static void friedSwapEndian(std::string &packed) {
+    if constexpr (std::endian::native != std::endian::little) {
+        for (size_t offset : {64, 72, 80}) {
+            uint64_t val;
+            std::memcpy(&val, packed.data() + offset, 8);
+            val = __builtin_bswap64(val);
+            std::memcpy(packed.data() + offset, &val, 8);
+        }
+    }
+}
 
 
 static const char USAGE[] =
@@ -29,6 +42,7 @@ EventToWrite parseFried(std::string_view lineSv) {
     if (!std::string_view(line).substr(0, i + 1).ends_with(",\"fried\":\"")) throw herr("fried parse error");
 
     std::string packed = from_hex(std::string_view(line).substr(i + 1, line.size() - i - 3));
+    friedSwapEndian(packed);
 
     line[i - 9] = '}';
     line.resize(i - 8);
@@ -76,8 +90,6 @@ void cmd_import(const std::vector<std::string> &subArgs) {
         std::string_view line(buf, (size_t)numRead-1);
 
         if (fried) {
-            if (std::endian::native != std::endian::little) throw herr("--fried currently only supported on little-endian CPUs"); // FIXME
-
             try {
                 writer.write(parseFried(line));
             } catch (std::exception &e) {


### PR DESCRIPTION
### Issue
- **Fixes:** FIXME at `cmd_export.cpp:34` and `cmd_import.cpp:79`

### Description

The `--fried` flag on `strfry export` and `strfry import` enables a fast binary format that embeds the packed event representation directly. The packed format stores `created_at`, `kind`, and `expiration` as raw uint64 values in native byte order. This means fried data exported on a little-endian system can't be imported on a big-endian one - strfry currently throws a hard error on non-LE systems.

This fix defines the fried wire format as always little-endian and adds `friedSwapEndian()` which byte-swaps the three uint64 fields (at offsets 64, 72, 80) between native and LE. Using `if constexpr`, the swap is a compile-time no-op on little-endian systems - zero runtime cost for x86/ARM-LE.

### Testing
- Haven't been tested because I do not own such a system but I have properly reviewed the code properly and believe it will work
- Can wait for this to get merged after I can somehow check this on any big-endian device