### PR TITLE
perf(events): skip redundant writer dup probe when caller pre-checked

### DIFF
--- a/src/WriterPipeline.h
+++ b/src/WriterPipeline.h
@@ -145,6 +145,7 @@ struct WriterPipeline {
                             continue;
                         }
 
+                        event.preChecked = true; // pre-filter above already ran lookupEventById in ro txn
                         newEventsToProc.emplace_back(std::move(event));
                     }
                 }

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -266,7 +266,10 @@ void writeEvents(lmdb::txn &txn, NegentropyFilterCache &neFilterCache, std::vect
 
             PackedEventView packed(ev.packedStr);
 
-            if (lookupEventById(txn, packed.id()) || (i != 0 && ev.id() == evs[i-1].id())) {
+            bool isDup = (i != 0 && ev.id() == evs[i-1].id());
+            if (!isDup && !ev.preChecked) isDup = (bool) lookupEventById(txn, packed.id());
+
+            if (isDup) {
                 ev.status = EventWriteStatus::Duplicate;
                 continue;
             }

--- a/src/events.h
+++ b/src/events.h
@@ -70,6 +70,10 @@ struct EventToWrite {
     void *userData = nullptr;
     EventWriteStatus status = EventWriteStatus::Pending;
     uint64_t levId = 0;
+    // Set when the caller already probed this id via lookupEventById() from the same
+    // thread that will open writeEvents()'s txn_rw (e.g. WriterPipeline). Do not set
+    // from cross-thread paths (e.g. RelayIngester) where the probe snapshot may be stale.
+    bool preChecked = false;
 
     EventToWrite() {}
 


### PR DESCRIPTION
### Issue
- writeEvents() was calling lookupEventById() on every event even when WriterPipeline had just run the same lookup in the same thread, so import/sync/router paid two B-tree seeks per event

### Description

- `WriterPipeline` (used by `strfry import` / `sync` / `router`) already probes `lookupEventById` under a read-only txn right before opening its `txn_rw` and calling `writeEvents()`. The same probe then runs again inside `writeEvents` for every event. Consolidates to one probe on that path.

- Adds `bool preChecked` on `EventToWrite`. When set, `writeEvents()` skips `lookupEventById` but still runs the unconditional intra-batch guard (`ev.id() == evs[i-1].id()`). `WriterPipeline` sets the flag right after its pre-filter.

- `RelayIngester` → `RelayWriter` is intentionally not changed: the ingester's ro-txn is a batch-start snapshot and with multiple ingester threads its probe can be stale by the time the writer processes the message; skipping the writer probe there would race and double-insert.