### PR TITLE
Fix Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ ENV TZ=Europe/London
 
 WORKDIR /build
 
-COPY . .
-
 RUN \
   apk --no-cache add \
     linux-headers \
@@ -24,12 +22,16 @@ RUN \
     lmdb-dev \
     flatbuffers-dev \
     libsecp256k1-dev \
-    zstd-dev \
-  && rm -rf /var/cache/apk/* \
-  && git submodule update --init \
-  && make setup-golpe \
-  && make clean \
-  && make -j4
+    zstd-dev
+
+COPY . .
+
+RUN git submodule update --init
+
+RUN make setup-golpe
+
+RUN --mount=type=cache,target=/build/.cache \
+    make -j4
 
 FROM alpine:3.18.3
 
@@ -46,6 +48,8 @@ RUN \
   && rm -rf /var/cache/apk/*
 
 COPY --from=build /build/strfry strfry
+COPY --from=build /build/strfry.conf strfry.conf
+COPY --from=build /build/strfry-db strfry-db
 
 EXPOSE 7777
 

--- a/ubuntu.Dockerfile
+++ b/ubuntu.Dockerfile
@@ -1,18 +1,25 @@
-FROM ubuntu:jammy as build
+FROM ubuntu:jammy AS build
+
 ENV TZ=Europe/London
+
 WORKDIR /build
+
 RUN apt update && apt install -y --no-install-recommends \
     git g++ make pkg-config libtool ca-certificates \
     libssl-dev zlib1g-dev liblmdb-dev libflatbuffers-dev \
     libsecp256k1-dev libzstd-dev
 
 COPY . .
-RUN git submodule update --init
-RUN make setup-golpe
-RUN make clean
-RUN make -j4
 
-FROM ubuntu:jammy as runner
+RUN git submodule update --init
+
+RUN make setup-golpe
+
+RUN --mount=type=cache,target=/build/.cache \
+    make -j4
+
+FROM ubuntu:jammy AS runner
+
 WORKDIR /app
 
 RUN apt update && apt install -y --no-install-recommends \
@@ -20,5 +27,10 @@ RUN apt update && apt install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /build/strfry strfry
+COPY --from=build /build/strfry.conf strfry.conf
+COPY --from=build /build/strfry-db strfry-db
+
+EXPOSE 7777
+
 ENTRYPOINT ["/app/strfry"]
 CMD ["relay"]


### PR DESCRIPTION
The current Dockerfiles won't work because they only copy the `strfry` executable. `strfry` expects a config file and `strfry-db` in the pwd. 

Also added a bunch of optimizations like caching for faster builds.