### PR TITLE
fix(filters): refresh validator config version

### DIFF
--- a/src/filters.h
+++ b/src/filters.h
@@ -328,7 +328,10 @@ struct FilterValidator {
     void validate(const NostrFilterGroup &fg) {
         if (!cfg().relay__filterValidation__enabled) return;
 
-        if (configVer != cfg().version()) setupValidator();
+        if (configVer != cfg().version()) {
+            setupValidator();
+            configVer = cfg().version();
+        }
 
         size_t numFilters = fg.filters.size();
         if (numFilters < cfg().relay__filterValidation__minFiltersPerReq ||


### PR DESCRIPTION
While reading through the REQ validation path, i noticed that `FilterValidator` already tracks a `configVer`,but never refreshes it after rebuilding `allowedKinds`

That means with `relay.filterValidation.enabled = true`, the validator keeps rebuilding its allowed-kinds state on every validated REQ instead of only when the config changes. If `allowedKinds` is set, it also reparses the comma-separated kind list each time.

This just updates `configVer` after a successful rebuild. It should not change validation behavior, just makes the existing cache guard work as intended.

I also checked it locally by temporarily logging `setupValidator()` and sending repeated REQs with filter validation enabled:
- before: it ran once per REQ
- after: it ran once for the current config version

Tested:
`make -j4`
