### PR TITLE
Pubkeys in NIP-11 are supposed to be hex pubkey only

### DIFF
--- a/strfry.conf
+++ b/strfry.conf
@@ -67,10 +67,10 @@ relay {
         # NIP-11: Detailed information about relay, free-form
         description = "This is a strfry instance."
 
-        # NIP-11: Administrative nostr pubkey (in npub or 32-byte HEX format), for contact purposes
+        # NIP-11: Administrative nostr pubkey (32-byte HEX format), for contact purposes
         pubkey = ""
 
-        # NIP-11: Relay's own pubkey (in npub or 32-byte HEX format)
+        # NIP-11: Relay's own pubkey (32-byte HEX format)
         self = ""
 
         # NIP-11: Alternative administrative contact (email, website, etc)


### PR DESCRIPTION
> n administrative contact may be listed with a pubkey, in the same format as Nostr events **(32-byte hex for a secp256k1 public key).**

[source](https://github.com/nostr-protocol/nips/blob/master/11.md#pubkey)

> A relay MAY maintain an identity independent from its administrator using the self field, **which MUST be a 32-byte hex public key.**

[source](
https://github.com/nostr-protocol/nips/blob/master/11.md#self)




