### PR TITLE
feat(relay): add max_event_tags and restrictedWrites to limitation

### DIFF
--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -98,6 +98,7 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
                     { "max_message_length", cfg().relay__maxWebsocketPayloadSize },
                     { "max_subscriptions", cfg().relay__maxSubsPerConnection },
                     { "max_limit", cfg().relay__maxFilterLimit },
+                    { "max_event_tags", cfg().events__maxNumTags },
                 }) },
             });
 
@@ -110,6 +111,11 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
             if (cfg().relay__info__self.size()) nip11["self"] = maybeNpub(cfg().relay__info__self);
             if (cfg().relay__info__privacy.size()) nip11["privacy_policy"] = cfg().relay__info__privacy;
             if (cfg().relay__info__terms.size()) nip11["terms_of_service"] = cfg().relay__info__terms;
+            if (cfg().relay__writePolicy__plugin.empty()) {
+                nip11["limitation"]["restricted_writes"] = false;
+            } else if (!cfg().relay__writePolicy__restrictedWrites.empty()) {
+                nip11["limitation"]["restricted_writes"] = cfg().relay__writePolicy__restrictedWrites == "true";
+            }
 
             rendered = preGenerateHttpResponse("application/json", tao::json::to_string(nip11));
             ver = cfg().version();

--- a/src/apps/relay/cmd_relay.cpp
+++ b/src/apps/relay/cmd_relay.cpp
@@ -29,6 +29,10 @@ static void checkConfig() {
     if (cfg().events__rejectEphemeralEventsOlderThanSeconds >= cfg().events__ephemeralEventsLifetimeSeconds) {
         LW << "rejectEphemeralEventsOlderThanSeconds is >= ephemeralEventsLifetimeSeconds, which could result in unnecessary disk activity";
     }
+
+    if (!cfg().relay__writePolicy__plugin.empty() && cfg().relay__writePolicy__restrictedWrites.empty()) {
+        LW << "A writePolicy.plugin is configured but writePolicy.restrictedWrites is not set. Set it to true or false in strfry.conf to advertise the correct NIP-11 limitation.";
+    }
 }
 
 

--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -92,6 +92,9 @@ config:
   - name: relay__writePolicy__timeoutSeconds
     desc: "Number of seconds to wait for a plugin to respond"
     default: 10
+  - name: relay__writePolicy__restrictedWrites
+    desc: "NIP-11: Set to \"true\" to advertise restricted_writes, \"false\" to explicitly deny. Empty (default) warns at startup if a plugin is configured but not set."
+    default: ""
 
   - name: relay__compression__enabled
     desc: "Use permessage-deflate compression if supported by client. Reduces bandwidth, but slight increase in CPU"

--- a/strfry.conf
+++ b/strfry.conf
@@ -130,6 +130,11 @@ relay {
 
         # Number of seconds to wait for a plugin to respond
         timeoutSeconds = 10
+
+        # NIP-11: If true, advertises restricted_writes in the relay's limitation info.
+        # Set when the write policy enforces non-standard conditions (e.g. whitelist, niche kinds).
+        # NOT for generic anti-spam (keyword filter, rate limit, regex, etc).
+        restrictedWrites = false
     }
 
     compression {


### PR DESCRIPTION
right now strfry doesn't include max_event_tags in its `limitation`; easily derived from `cfg().events__maxNumTags`

it also doesn't include restricted_writes; so set it to false if there's no write policy, and if there is, ask the user to configure whether their write policy is more "whitelist" or "niches only" vs "anti-spam"