### PR TITLE
Dark mode support for landing page

### DIFF
--- a/src/tmpls/landing.tmpl
+++ b/src/tmpls/landing.tmpl
@@ -29,6 +29,9 @@
             footer, header, hgroup, menu, nav, section {
                 display: block;
             }
+            html {
+                color-scheme: light dark;
+            }
             body {
                 line-height: 1;
             }
@@ -83,8 +86,8 @@
             }
 
             table th {
-                color: white;
-                background-color: black;
+                color: Canvas;
+                background-color: CanvasText;
                 font-size: 110%;
             }
 
@@ -100,7 +103,7 @@
             }
 
             table tr:nth-child(even) {
-                background-color: #f2f2f2;
+                background-color: Field;
             }
 
             table td,th {


### PR DESCRIPTION
Add `color-scheme: light dark;` and use standard colors that will adapt to light/dark mode