### PR TITLE
macOS: clamp NOFILES rlimit gracefully (like FreeBSD)

### DIFF
--- a/src/onAppStartup.cpp
+++ b/src/onAppStartup.cpp
@@ -83,7 +83,7 @@ static void setRLimits() {
 
     if (getrlimit(RLIMIT_NOFILE, &curr)) throw herr("couldn't call getrlimit: ", strerror(errno));
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__APPLE__)
     LI << "getrlimit NOFILES limit current " <<  curr.rlim_cur << " with max of " <<  curr.rlim_max;
     if (cfg().relay__nofiles > curr.rlim_max) {
         LI << "Unable to set NOFILES limit to " << cfg().relay__nofiles << ", exceeds max of " << curr.rlim_max;


### PR DESCRIPTION
As discussed in #247.

On macOS, `setRLimits()` falls into the `#else` branch and aborts startup when the configured `nofiles` exceeds the hard max. This extends the existing FreeBSD graceful-clamp branch to `__APPLE__` (the one-line change suggested in #247), so the limit is clamped instead of throwing.

`#ifdef __FreeBSD__` -> `#if defined(__FreeBSD__) || defined(__APPLE__)`

Verified on macOS: with `nofiles` set above the OS max, the relay now logs the clamp and starts normally instead of aborting. Linux is unaffected.
