### PR TITLE
Restricted reads

### DIFF
--- a/src/PrometheusMetrics.h
+++ b/src/PrometheusMetrics.h
@@ -109,6 +109,12 @@ public:
     Gauge activeConnections;
     Counter slowClientTerminations;
 
+    // AUTH metrics
+    Counter authChallengesSentTotal;
+    Counter authSuccessTotal;
+    Counter authFailureTotal;
+    Gauge authenticatedConnections;
+
     // Generate Prometheus text format output
     std::string render() const {
         std::ostringstream out;
@@ -166,6 +172,23 @@ public:
         out << "# HELP strfry_slow_client_terminations_total Connections closed for exceeding relay.maxPendingOutboundBytes\n";
         out << "# TYPE strfry_slow_client_terminations_total counter\n";
         out << "strfry_slow_client_terminations_total " << slowClientTerminations.get() << "\n";
+
+        // AUTH metrics
+        out << "# HELP strfry_auth_challenges_sent_total AUTH challenges sent to clients\n";
+        out << "# TYPE strfry_auth_challenges_sent_total counter\n";
+        out << "strfry_auth_challenges_sent_total " << authChallengesSentTotal.get() << "\n";
+
+        out << "# HELP strfry_auth_success_total Successful AUTH responses\n";
+        out << "# TYPE strfry_auth_success_total counter\n";
+        out << "strfry_auth_success_total " << authSuccessTotal.get() << "\n";
+
+        out << "# HELP strfry_auth_failure_total Failed AUTH responses\n";
+        out << "# TYPE strfry_auth_failure_total counter\n";
+        out << "strfry_auth_failure_total " << authFailureTotal.get() << "\n";
+
+        out << "# HELP strfry_authenticated_connections_current Current number of AUTHed connections\n";
+        out << "# TYPE strfry_authenticated_connections_current gauge\n";
+        out << "strfry_authenticated_connections_current " << authenticatedConnections.get() << "\n";
 
         return out.str();
     }

--- a/src/ReadRestrictor.h
+++ b/src/ReadRestrictor.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include <string_view>
+#include "PackedEvent.h"
+#include "Bytes32.h"
+#include "config.h"
+#include "filters.h"
+#include "global.h"
+#include "parallel_hashmap/phmap.h"
+
+struct ReadRestrictor {
+private:
+    inline static uint64_t configVer = 0;
+    inline static flat_hash_set<uint64_t> restrictedKinds_;
+
+public:
+    static void init(){
+        parseCommaSeparatedKinds(cfg().relay__auth__restrictedReadKinds, restrictedKinds_);
+    }
+
+    static flat_hash_set<uint64_t>& restrictedKinds() {
+        if (configVer != cfg().version()) {
+            init();
+            configVer = cfg().version();
+        }
+        return restrictedKinds_;
+    }
+
+    static bool isFilterGroupFullyRestricted(const NostrFilterGroup &fg) {
+        if (restrictedKinds().empty() || fg.filters.empty()) return false;
+        for (const auto& f : fg.filters) {
+            if (!isFilterFullyRestricted(f)) return false;
+        }
+        return true;
+    }
+
+    static bool isFilterFullyRestricted(const NostrFilter &filter) {
+        if (!filter.kinds) return false;
+
+        for (size_t i = 0; i < filter.kinds->size(); ++i) {
+            uint64_t kind = filter.kinds->at(i);
+
+            if (!restrictedKinds().contains(kind)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    static bool isFilterAllowedToCount(const NostrFilterGroup &fg, Bytes32 pubkey) {
+        if (restrictedKinds().empty()) return true;
+        for (const auto &f: fg.filters) {
+            if (!f.kinds) continue;
+            bool hasSomeRestrictedKind = false;
+            for(size_t i = 0; i<f.kinds->size(); ++i) {
+                uint64_t kind = f.kinds->at(i);
+                if (restrictedKinds().contains(kind)) {
+                    hasSomeRestrictedKind = true;
+                    break;
+                }
+            }
+            if (hasSomeRestrictedKind) {
+                if (pubkey.isNull()) {
+                    return false;
+                }
+                bool authorScoped = f.authors && allPubkeysMatch(*f.authors, pubkey);
+                bool pScoped = false;
+                if (auto it = f.tags.find('p'); it != f.tags.end()) {
+                    pScoped = allPubkeysMatch(it->second, pubkey);
+                }
+                if (!authorScoped && !pScoped) return false;
+            }
+        }
+        return true;
+    }
+
+    static bool allPubkeysMatch(const FilterSetBytes& set, Bytes32 authed) {
+        if (set.size() == 0) return false;
+
+        for (size_t i = 0; i < set.size(); ++i) {
+            Bytes32 val(set.at(i));
+            if (val != authed) return false;
+        }
+        return true;
+    }
+
+    // Returns true if the event should be sent to the subscriber
+    static bool shouldSendToSubscriber(const PackedEventView &packed, const Bytes32 &subscriberAuthedPubkey) {
+        if (!(restrictedKinds().contains(packed.kind()) && cfg().relay__auth__restrictReadToInvolvedPubkey)) {
+            return true;
+        }
+
+        if (subscriberAuthedPubkey.isNull()) {
+            return false;
+        }
+
+        Bytes32 recipientPubkey;
+        bool foundRecipient = false;
+
+        packed.foreachTag([&](char tagName, std::string_view tagVal) {
+            if (tagName == 'p' && tagVal.size() == 32) {
+                recipientPubkey = Bytes32(tagVal);
+                foundRecipient = true;
+                return false;
+            }
+            return true;
+        });
+
+        if (!foundRecipient) {
+            return false;
+        }
+
+        return subscriberAuthedPubkey == recipientPubkey || subscriberAuthedPubkey == packed.pubkey();
+    }
+};

--- a/src/apps/relay/AuthSession.h
+++ b/src/apps/relay/AuthSession.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+#include "Bytes32.h"
+
+struct AuthSession {
+
+  static constexpr size_t kChallengeSize = 22;
+
+  std::array<char, kChallengeSize> challenge{};
+  Bytes32 authed;
+
+  AuthSession(std::string_view token) {
+    if (token.size() != kChallengeSize)
+      throw herr("challenge size not ", kChallengeSize, " bytes");
+    ::memcpy(challenge.data(), token.data(), kChallengeSize);
+  }
+
+  void markAuthed(Bytes32 pubkey) { authed = pubkey; }
+
+  bool isAuthed() const { return !authed.isNull(); }
+
+  std::string_view challengeSv() const {
+    return std::string_view(challenge.data(), challenge.size());
+  }
+};

--- a/src/apps/relay/RelayIngester.cpp
+++ b/src/apps/relay/RelayIngester.cpp
@@ -43,6 +43,7 @@ void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
                             try {
                                 ingesterProcessAuth(rsctx, msg->connId, arr[1]);
                             } catch (std::exception &e) {
+                                PrometheusMetrics::getInstance().authFailureTotal.inc();
                                 sendOKResponse(msg->connId, arr[1].is_object() && arr[1].at("id").is_string() ? arr[1].at("id").get_string() : "?",
                                                false, std::string("error: ") + e.what());
                             }
@@ -91,7 +92,9 @@ void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
             } else if (auto msg = std::get_if<MsgIngester::CloseConn>(&newMsg.msg)) {
                 auto connId = msg->connId;
 
-                rsctx.connIdToAuthStatus.erase(connId);
+                PrometheusMetrics::getInstance().authenticatedConnections.dec();
+                rsctx.connIdToAuthSession.erase(connId);
+                
 
                 tpWriter.dispatch(connId, MsgWriter{MsgWriter::CloseConn{connId}});
                 tpReqWorker.dispatch(connId, MsgReqWorker{MsgReqWorker::CloseConn{connId}});
@@ -153,11 +156,13 @@ void RelayServer::ingesterProcessEvent(lmdb::txn &txn, RelayServerCtx &rsctx, ui
                 return;
             }
 
-            auto it = rsctx.connIdToAuthStatus.find(connId);
-            if (it == rsctx.connIdToAuthStatus.end()) {
+            auto it = rsctx.connIdToAuthSession.find(connId);
+
+            if (it == rsctx.connIdToAuthSession.end()) {
                 // we haven't sent an AUTH event for this, so first we generate a challenge for this connection
                 auto challenge = rsctx.challengeGenerator.get();
-                rsctx.connIdToAuthStatus.emplace(connId, challenge);
+                
+                rsctx.connIdToAuthSession.emplace(connId, challenge);
 
                 LI << "[" << connId << "] Protected event, requesting AUTH: " << idHex;
                 sendAuthChallenge(connId, challenge);
@@ -252,8 +257,8 @@ void RelayServer::ingesterProcessAuth(RelayServerCtx &rsctx, uint64_t connId, co
 
     if (packed.kind() != 22242) throw herr("wrong event kind, expected 22242");
 
-    auto it = rsctx.connIdToAuthStatus.find(connId);
-    if (it == rsctx.connIdToAuthStatus.end()) throw herr("no auth status available for connection");
+    auto it = rsctx.connIdToAuthSession.find(connId);
+    if (it == rsctx.connIdToAuthSession.end()) throw herr("no auth status available for connection");
 
     auto &as = it->second;
 
@@ -280,7 +285,9 @@ void RelayServer::ingesterProcessAuth(RelayServerCtx &rsctx, uint64_t connId, co
     if (!foundCorrectRelayUrl) throw herr("incorrect or missing relay tag, expected: " + cfg().relay__auth__serviceUrl);
 
     // set the connection as authenticated with this pubkey
-    as.authed = packed.pubkey();
+    as.markAuthed(packed.pubkey());
+    PrometheusMetrics::getInstance().authSuccessTotal.inc();
+    PrometheusMetrics::getInstance().authenticatedConnections.inc();
 
     LI << "[" << connId << "] AUTHed as " << to_hex(packed.pubkey());
     sendOKResponse(connId, to_hex(packed.id()), true, "successfully authenticated");

--- a/src/apps/relay/RelayIngester.cpp
+++ b/src/apps/relay/RelayIngester.cpp
@@ -1,5 +1,6 @@
 #include "RelayServer.h"
 #include "jsonParseUtils.h"
+#include "ReadRestrictor.h"
 
 
 void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
@@ -73,7 +74,7 @@ void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
                             if (!cfg().relay__negentropy__enabled) throw herr("negentropy disabled");
 
                             try {
-                                ingesterProcessNegentropy(txn, msg->connId, arr);
+                                ingesterProcessNegentropy(txn, rsctx, msg->connId, arr);
                             } catch (std::exception &e) {
                                 sendNoticeError(msg->connId, std::string("negentropy error: ") + e.what());
                             }
@@ -94,7 +95,6 @@ void RelayServer::runIngester(ThreadPool<MsgIngester>::Thread &thr) {
 
                 PrometheusMetrics::getInstance().authenticatedConnections.dec();
                 rsctx.connIdToAuthSession.erase(connId);
-                
 
                 tpWriter.dispatch(connId, MsgWriter{MsgWriter::CloseConn{connId}});
                 tpReqWorker.dispatch(connId, MsgReqWorker{MsgReqWorker::CloseConn{connId}});
@@ -224,6 +224,31 @@ void RelayServer::ingesterProcessReq(lmdb::txn &txn, RelayServerCtx &rsctx, uint
         throw herr("filter validation failed: ", e.what());
     }
 
+    auto it = rsctx.connIdToAuthSession.find(connId);
+    bool isAuthed = (it != rsctx.connIdToAuthSession.end());
+    bool requiresAuth = false;
+
+    if (countOnly) {
+        // COUNT can't be filtered per event, so a restricted-kind filter must be
+        // scoped to the client's own pubkeys via authors/#p.
+        requiresAuth = !ReadRestrictor::isFilterAllowedToCount(filterGroup, isAuthed ? it->second.authed : Bytes32());
+    } else {
+        // if the filter group contains no filter that has a kind that is not restricted,
+        // that means an unauthenticated client won't be able to see anything
+        if (ReadRestrictor::isFilterGroupFullyRestricted(filterGroup)) {
+            requiresAuth = !isAuthed;
+        }
+    }
+
+    if (requiresAuth) {
+        auto challenge = rsctx.challengeGenerator.get();
+        rsctx.connIdToAuthSession.emplace(connId, challenge);
+        LI << "[" << connId << "] Requesting initial AUTH";
+        sendAuthChallenge(connId, challenge);
+        sendClosedError(connId, outSubIdStr, "auth-required: requested filter requires authentication");
+        return;
+    }
+
     Subscription sub(connId, outSubIdStr, std::move(filterGroup), countOnly);
 
     tpReqWorker.dispatch(connId, MsgReqWorker{MsgReqWorker::NewSub{std::move(sub)}});
@@ -286,6 +311,8 @@ void RelayServer::ingesterProcessAuth(RelayServerCtx &rsctx, uint64_t connId, co
 
     // set the connection as authenticated with this pubkey
     as.markAuthed(packed.pubkey());
+    tpReqWorker.dispatch(connId, MsgReqWorker{MsgReqWorker::SetAuth{connId, packed.pubkey()}});
+    tpReqMonitor.dispatch(connId, MsgReqMonitor{MsgReqMonitor::SetAuth{connId, packed.pubkey()}});
     PrometheusMetrics::getInstance().authSuccessTotal.inc();
     PrometheusMetrics::getInstance().authenticatedConnections.inc();
 
@@ -293,7 +320,7 @@ void RelayServer::ingesterProcessAuth(RelayServerCtx &rsctx, uint64_t connId, co
     sendOKResponse(connId, to_hex(packed.id()), true, "successfully authenticated");
 }
 
-void RelayServer::ingesterProcessNegentropy(lmdb::txn &txn, uint64_t connId, const tao::json::value &arr) {
+void RelayServer::ingesterProcessNegentropy(lmdb::txn &txn, RelayServerCtx &rsctx, uint64_t connId, const tao::json::value &arr) {
     const auto &vals = arr.get_array();
 
     if (vals.size() < 2) throw herr("negentropy query missing elements");
@@ -310,6 +337,26 @@ void RelayServer::ingesterProcessNegentropy(lmdb::txn &txn, uint64_t connId, con
         if (!filterJson.is_object()) throw herr("negentropy filter must be an object");
 
         NostrFilterGroup filter(filterJson, maxFilterLimit);
+
+        // if the filter group contains no filter that has a kind that is not restricted,
+        // that means an unauthenticated client won't be able to see anything
+        if (ReadRestrictor::isFilterGroupFullyRestricted(filter)) {
+            auto it = rsctx.connIdToAuthSession.find(connId);
+            if (it == rsctx.connIdToAuthSession.end()) {
+                auto challenge = rsctx.challengeGenerator.get();
+                rsctx.connIdToAuthSession.emplace(connId, challenge);
+                LI << "[" << connId << "] Requesting initial AUTH";
+                sendAuthChallenge(connId, challenge);
+                PROM_INC_RELAY_MSG("NEG-ERR");
+                sendToConn(connId, tao::json::to_string(tao::json::value::array({
+                    "NEG-ERR",
+                    subscriptionStr,
+                    "auth-required: requested filter requires authentication"
+                })));
+                return;
+            }
+        }
+
         Subscription sub(connId, subscriptionStr, std::move(filter));
 
         filterJson.get_object().erase("since");

--- a/src/apps/relay/RelayNegentropy.cpp
+++ b/src/apps/relay/RelayNegentropy.cpp
@@ -5,7 +5,7 @@
 
 #include "RelayServer.h"
 #include "QueryScheduler.h"
-
+#include "ReadRestrictor.h"
 
 struct NegentropyViews {
     struct MemoryView {
@@ -90,7 +90,7 @@ struct NegentropyViews {
 void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
     QueryScheduler queries;
     NegentropyViews views;
-
+    flat_hash_map<uint64_t, Bytes32> connIdToAuthedPubkey;
 
     auto handleReconcile = [&](uint64_t connId, const SubId &subId, negentropy::StorageBase &storage, const std::string &msg) {
         std::string resp;
@@ -168,6 +168,10 @@ void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
             try {
                 auto ev = lookupEventByLevId(txn, levId);
                 PackedEventView packed(ev.buf);
+                auto it = connIdToAuthedPubkey.find(sub.connId);
+                Bytes32 subscriberAuthedPubkey = it == connIdToAuthedPubkey.end() ? Bytes32() : it->second;
+
+                if (ReadRestrictor::shouldSendToSubscriber(packed, subscriberAuthedPubkey))
                 view->storageVector.insert(packed.created_at(), packed.id());
             } catch (std::exception &) {
                 // levId was deleted when query was paused
@@ -258,6 +262,8 @@ void RelayServer::runNegentropy(ThreadPool<MsgNegentropy>::Thread &thr) {
 
                     handleReconcile(msg->connId, msg->subId, subStorage, msg->negPayload);
                 }
+            } else if (auto msg = std::get_if<MsgNegentropy::SetAuth>(&newMsg.msg)) {
+                connIdToAuthedPubkey[msg->connId] = msg->authed;
             } else if (auto msg = std::get_if<MsgNegentropy::NegClose>(&newMsg.msg)) {
                 LI << "[" << msg->connId << "] negentropy CLOSE session=" << msg->subId.sv();
 

--- a/src/apps/relay/RelayReqMonitor.cpp
+++ b/src/apps/relay/RelayReqMonitor.cpp
@@ -1,6 +1,7 @@
 #include "RelayServer.h"
 
 #include "ActiveMonitors.h"
+#include "ReadRestrictor.h"
 
 
 
@@ -16,6 +17,7 @@ void RelayServer::runReqMonitor(ThreadPool<MsgReqMonitor>::Thread &thr) {
 
     Decompressor decomp;
     ActiveMonitors monitors;
+    flat_hash_map<uint64_t, Bytes32> connIdToAuthedPubkey;
     uint64_t currEventId = MAX_U64;
 
     while (1) {
@@ -29,10 +31,15 @@ void RelayServer::runReqMonitor(ThreadPool<MsgReqMonitor>::Thread &thr) {
         for (auto &newMsg : newMsgs) {
             if (auto msg = std::get_if<MsgReqMonitor::NewSub>(&newMsg.msg)) {
                 auto connId = msg->sub.connId;
+                auto it = connIdToAuthedPubkey.find(connId);
+                Bytes32 connAuthedPubkey = it == connIdToAuthedPubkey.end() ? Bytes32() : it->second;
 
                 env.foreach_Event(txn, [&](auto &ev){
-                    if (msg->sub.filterGroup.doesMatch(PackedEventView(ev.buf))) {
-                        sendEvent(connId, msg->sub.subId, getEventJson(txn, decomp, ev.primaryKeyId));
+                    PackedEventView packed(ev.buf);
+                    if (msg->sub.filterGroup.doesMatch(packed)) {
+                        if (ReadRestrictor::shouldSendToSubscriber(packed, connAuthedPubkey)) {
+                            sendEvent(connId, msg->sub.subId, getEventJson(txn, decomp, ev.primaryKeyId));
+                        }
                     }
 
                     return true;
@@ -43,14 +50,32 @@ void RelayServer::runReqMonitor(ThreadPool<MsgReqMonitor>::Thread &thr) {
                 if (!monitors.addSub(txn, std::move(msg->sub), latestEventId)) {
                     sendNoticeError(connId, std::string("too many concurrent REQs"));
                 }
+            } else if (auto msg = std::get_if<MsgReqMonitor::SetAuth>(&newMsg.msg)) {
+                connIdToAuthedPubkey[msg->connId] = msg->authed;
             } else if (auto msg = std::get_if<MsgReqMonitor::RemoveSub>(&newMsg.msg)) {
                 monitors.removeSub(msg->connId, msg->subId);
             } else if (auto msg = std::get_if<MsgReqMonitor::CloseConn>(&newMsg.msg)) {
+                connIdToAuthedPubkey.erase(msg->connId);
                 monitors.closeConn(msg->connId);
             } else if (std::get_if<MsgReqMonitor::DBChange>(&newMsg.msg)) {
                 env.foreach_Event(txn, [&](auto &ev){
                     monitors.process(txn, ev, [&](RecipientList &&recipients, uint64_t levId){
-                        sendEventToBatch(std::move(recipients), std::string(getEventJson(txn, decomp, levId)));
+                        PackedEventView packed(ev.buf);
+                        if (ReadRestrictor::restrictedKinds().contains(packed.kind())) {
+                            RecipientList filteredRecipients;
+                            for (const auto &recipient : recipients) {
+                                auto it = connIdToAuthedPubkey.find(recipient.connId);
+                                Bytes32 authedPubkey = it == connIdToAuthedPubkey.end() ? Bytes32() : it->second;
+                                if (ReadRestrictor::shouldSendToSubscriber(packed, authedPubkey)) {
+                                    filteredRecipients.emplace_back(recipient);
+                                }
+                            }
+                            if (!filteredRecipients.empty()) {
+                                sendEventToBatch(std::move(filteredRecipients), std::string(getEventJson(txn, decomp, levId)));
+                            }
+                        } else {
+                            sendEventToBatch(std::move(recipients), std::string(getEventJson(txn, decomp, levId)));
+                        }
                     });
                     return true;
                 }, false, currEventId + 1);

--- a/src/apps/relay/RelayReqWorker.cpp
+++ b/src/apps/relay/RelayReqWorker.cpp
@@ -1,13 +1,21 @@
 #include "RelayServer.h"
 #include "QueryScheduler.h"
+#include "ReadRestrictor.h"
 
 
 void RelayServer::runReqWorker(ThreadPool<MsgReqWorker>::Thread &thr) {
     Decompressor decomp;
     QueryScheduler queries;
+    flat_hash_map<uint64_t, Bytes32> connIdToAuthedPubkey;
 
     queries.onEvent = [&](lmdb::txn &txn, const auto &sub, uint64_t levId, std::string_view eventPayload){
         if (sub.countOnly) return;
+        auto it = connIdToAuthedPubkey.find(sub.connId);
+        Bytes32 subscriberAuthedPubkey = it == connIdToAuthedPubkey.end() ? Bytes32() : it->second;
+        if (!ReadRestrictor::shouldSendToSubscriber(PackedEventView(eventPayload), subscriberAuthedPubkey)) {
+            return; 
+        }
+        
         sendEvent(sub.connId, sub.subId, decodeEventPayload(txn, decomp, eventPayload, nullptr, nullptr));
     };
 
@@ -48,10 +56,13 @@ void RelayServer::runReqWorker(ThreadPool<MsgReqWorker>::Thread &thr) {
                 }
 
                 queries.process(txn);
+            } else if (auto msg = std::get_if<MsgReqWorker::SetAuth>(&newMsg.msg)) {
+                connIdToAuthedPubkey[msg->connId] = msg->authed;
             } else if (auto msg = std::get_if<MsgReqWorker::RemoveSub>(&newMsg.msg)) {
                 queries.removeSub(msg->connId, msg->subId);
                 tpReqMonitor.dispatch(msg->connId, MsgReqMonitor{MsgReqMonitor::RemoveSub{msg->connId, msg->subId}});
             } else if (auto msg = std::get_if<MsgReqWorker::CloseConn>(&newMsg.msg)) {
+                connIdToAuthedPubkey.erase(msg->connId);
                 queries.closeConn(msg->connId);
                 tpReqMonitor.dispatch(msg->connId, MsgReqMonitor{MsgReqMonitor::CloseConn{msg->connId}});
             }

--- a/src/apps/relay/RelayServer.h
+++ b/src/apps/relay/RelayServer.h
@@ -20,6 +20,7 @@
 #include "jsonParseUtils.h"
 #include "Decompressor.h"
 #include "PrometheusMetrics.h"
+#include "AuthSession.h"
 
 
 
@@ -150,29 +151,11 @@ struct MsgNegentropy : NonCopyable {
     MsgNegentropy(Var &&msg_) : msg(std::move(msg_)) {}
 };
 
-struct AuthStatus {
-    char challenge[22];
-    Bytes32 authed;
-
-    AuthStatus(std::string_view c) {
-        if (c.size() != 22) throw herr("challenge size not 22 bytes");
-        ::memcpy(challenge, c.data(), 22);
-    }
-
-    std::string_view challengeSv() const {
-        return std::string_view(challenge, sizeof(challenge));
-    }
-
-    bool isAuthed() const {
-        return !authed.isNull();
-    }
-};
-
 struct RelayServerCtx {
     secp256k1_context *secpCtx = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
     FilterValidator filterValidator;
     SessionToken::Generator challengeGenerator;
-    flat_hash_map<uint64_t, AuthStatus> connIdToAuthStatus;
+    flat_hash_map<uint64_t, AuthSession> connIdToAuthSession;
 };
 
 struct RelayServer {
@@ -194,7 +177,7 @@ struct RelayServer {
     void runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr);
 
     void runIngester(ThreadPool<MsgIngester>::Thread &thr);
-    void ingesterProcessEvent(lmdb::txn &txn, uint64_t connId, flat_hash_map<uint64_t, AuthStatus*> &connIdToAuthStatus, std::string ipAddr, secp256k1_context *secpCtx, const tao::json::value &origJson, std::vector<MsgWriter> &output);
+    void ingesterProcessEvent(lmdb::txn &txn, uint64_t connId, flat_hash_map<uint64_t, AuthSession*> &connIdToAuthStatus, std::string ipAddr, secp256k1_context *secpCtx, const tao::json::value &origJson, std::vector<MsgWriter> &output);
     void ingesterProcessEvent(lmdb::txn &txn, RelayServerCtx &rsctx, uint64_t connId, std::string ipAddr, const tao::json::value &origJson, std::vector<MsgWriter> &output);
     void ingesterProcessReq(lmdb::txn &txn, RelayServerCtx &rsctx, uint64_t connId, const tao::json::value &arr, bool countOnly, std::string &outSubIdStr);
     void ingesterProcessClose(lmdb::txn &txn, uint64_t connId, const tao::json::value &arr);
@@ -271,6 +254,7 @@ struct RelayServer {
 
     void sendAuthChallenge(uint64_t connId, std::string_view challenge) {
         PROM_INC_RELAY_MSG("AUTH");
+        PrometheusMetrics::getInstance().authChallengesSentTotal.inc();
         auto reply = tao::json::value::array({ "AUTH", challenge });
         tpWebsocket.dispatch(0, MsgWebsocket{MsgWebsocket::Send{connId, std::move(tao::json::to_string(reply))}});
         hubTrigger->send();

--- a/src/apps/relay/RelayServer.h
+++ b/src/apps/relay/RelayServer.h
@@ -88,6 +88,11 @@ struct MsgReqWorker : NonCopyable {
         Subscription sub;
     };
 
+    struct SetAuth {
+        uint64_t connId;
+        Bytes32 authed;
+    };
+
     struct RemoveSub {
         uint64_t connId;
         SubId subId;
@@ -97,7 +102,7 @@ struct MsgReqWorker : NonCopyable {
         uint64_t connId;
     };
 
-    using Var = std::variant<NewSub, RemoveSub, CloseConn>;
+    using Var = std::variant<NewSub, SetAuth, RemoveSub, CloseConn>;
     Var msg;
     MsgReqWorker(Var &&msg_) : msg(std::move(msg_)) {}
 };
@@ -105,6 +110,11 @@ struct MsgReqWorker : NonCopyable {
 struct MsgReqMonitor : NonCopyable {
     struct NewSub {
         Subscription sub;
+    };
+
+    struct SetAuth {
+        uint64_t connId;
+        Bytes32 authed;
     };
 
     struct RemoveSub {
@@ -119,7 +129,7 @@ struct MsgReqMonitor : NonCopyable {
     struct DBChange {
     };
 
-    using Var = std::variant<NewSub, RemoveSub, CloseConn, DBChange>;
+    using Var = std::variant<NewSub, SetAuth, RemoveSub, CloseConn, DBChange>;
     Var msg;
     MsgReqMonitor(Var &&msg_) : msg(std::move(msg_)) {}
 };
@@ -137,6 +147,11 @@ struct MsgNegentropy : NonCopyable {
         std::string negPayload;
     };
 
+    struct SetAuth {
+        uint64_t connId;
+        Bytes32 authed;
+    };
+
     struct NegClose {
         uint64_t connId;
         SubId subId;
@@ -146,7 +161,7 @@ struct MsgNegentropy : NonCopyable {
         uint64_t connId;
     };
 
-    using Var = std::variant<NegOpen, NegMsg, NegClose, CloseConn>;
+    using Var = std::variant<NegOpen, SetAuth, NegMsg, NegClose, CloseConn>;
     Var msg;
     MsgNegentropy(Var &&msg_) : msg(std::move(msg_)) {}
 };
@@ -182,7 +197,7 @@ struct RelayServer {
     void ingesterProcessReq(lmdb::txn &txn, RelayServerCtx &rsctx, uint64_t connId, const tao::json::value &arr, bool countOnly, std::string &outSubIdStr);
     void ingesterProcessClose(lmdb::txn &txn, uint64_t connId, const tao::json::value &arr);
     void ingesterProcessAuth(RelayServerCtx &rsctx, uint64_t connId, const tao::json::value &eventJson);
-    void ingesterProcessNegentropy(lmdb::txn &txn, uint64_t connId, const tao::json::value &origJson);
+    void ingesterProcessNegentropy(lmdb::txn &txn, RelayServerCtx &rsctx, uint64_t connId, const tao::json::value &origJson);
 
     void runWriter(ThreadPool<MsgWriter>::Thread &thr);
 

--- a/src/apps/relay/golpe.yaml
+++ b/src/apps/relay/golpe.yaml
@@ -21,6 +21,12 @@ config:
   - name: relay__auth__serviceUrl
     desc: "External relay URL (beginning with wss://). Required in order to validate challenge responses."
     default: ""
+  - name: relay__auth__restrictedReadKinds
+    desc: "Comma-separated list of event kinds that require NIP-42 AUTH to read via REQ/COUNT/NEG-OPEN. A filter with no 'kinds' field is treated as restricted. Example for DMs: '4,1059'."
+    default: "4, 1059"
+  - name: relay__auth__restrictReadToInvolvedPubkey
+    desc: "When a filter matches restrictedReadKinds, also require the authenticated pubkey to appear in its 'authors' or '#p' set."
+    default: true
 
   - name: relay__info__name
     desc: "NIP-11: Name of this server. Short/descriptive (< 30 characters)"

--- a/src/filters.h
+++ b/src/filters.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "config.h"
+#include "global.h"
 #include "golpe.h"
 
 #include "jsonParseUtils.h"
@@ -306,27 +308,7 @@ struct FilterValidator : NonCopyable {
     flat_hash_set<uint64_t> allowedKinds;
 
     void setupValidator() {
-        allowedKinds.clear();
-
-        std::string allowedKindsStr = cfg().relay__filterValidation__allowedKinds;
-
-        if (!allowedKindsStr.empty()) {
-            size_t pos = 0;
-            while (pos < allowedKindsStr.size()) {
-                size_t nextComma = allowedKindsStr.find(',', pos);
-                if (nextComma == std::string::npos) nextComma = allowedKindsStr.size();
-
-                std::string kindStr = allowedKindsStr.substr(pos, nextComma - pos);
-                size_t start = kindStr.find_first_not_of(" \t");
-                size_t end = kindStr.find_last_not_of(" \t");
-                if (start != std::string::npos && end != std::string::npos) {
-                    kindStr = kindStr.substr(start, end - start + 1);
-                    if (!kindStr.empty()) allowedKinds.insert(std::stoull(kindStr));
-                }
-
-                pos = nextComma + 1;
-            }
-        }
+       parseCommaSeparatedKinds(cfg().relay__filterValidation__allowedKinds, allowedKinds);
     }
 
     void validate(const NostrFilterGroup &fg) {

--- a/src/global.h
+++ b/src/global.h
@@ -18,5 +18,6 @@ uint64_t parseUint64(const std::string &s);
 std::string parseIP(const std::string &ip);
 uint64_t getDBVersion(lmdb::txn &txn);
 void exitOnSigPipe();
+void parseCommaSeparatedKinds(std::string_view str, flat_hash_set<uint64_t> &out); 
 
 extern lmdb::dbi negentropyDbi;

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -12,7 +12,7 @@
 #include <openssl/sha.h>
 
 #include "golpe.h"
-
+#include "global.h"
 
 
 
@@ -126,4 +126,26 @@ void exitOnSigPipe() {
     memset(&act, 0, sizeof act);
     act.sa_sigaction = [](int, siginfo_t*, void*){ ::exit(1); };
     if (sigaction(SIGPIPE, &act, nullptr)) throw herr("couldn't run sigaction(): ", strerror(errno));
+}
+
+
+void parseCommaSeparatedKinds(std::string_view str, flat_hash_set<uint64_t> &out) {
+    out.clear();
+    if (str.empty()) return;
+
+    size_t pos = 0;
+    while (pos < str.size()) {
+        size_t nextComma = str.find(',', pos);
+        if (nextComma == std::string::npos) nextComma = str.size();
+
+        std::string_view kindStr = str.substr(pos, nextComma - pos);
+        size_t start = kindStr.find_first_not_of(" \t");
+        size_t end = kindStr.find_last_not_of(" \t");
+        if (start != std::string::npos && end != std::string::npos) {
+            kindStr = kindStr.substr(start, end - start + 1);
+            if (!kindStr.empty()) out.insert(std::stoull(std::string(kindStr)));
+        }
+
+        pos = nextComma + 1;
+    }
 }

--- a/strfry.conf
+++ b/strfry.conf
@@ -58,6 +58,15 @@ relay {
 
         # External relay URL (beginning with wss://). Required in order to validate challenge responses.
         serviceUrl = ""
+
+        # Comma-separated list of kinds that require NIP-42 AUTH to read via
+        # REQ/COUNT/NEG-OPEN. A filter with no "kinds" field is treated as
+        # restricted. Example for DMs: "4,1059".
+        restrictedReadKinds = ""
+
+        # When a filter matches restrictedReadKinds, also require the authed
+        # pubkey to appear in its "authors" or "#p" set.
+        restrictReadToInvolvedPubkey = true
     }
 
     info {


### PR DESCRIPTION
we add support for two configuration options:
`restrictedReadKinds` and `restrictReadToInvolvedPubkey`.

If all the kinds in a req filter are in `restrictedReadKinds` i.e., all the events the client wants to fetch need authentication, the client will have to be authenticated for a successful subscription.

If `restrictReadToInvolvedPubkey` is set to true, events are filtered based on whether the client is the author or one of the pubkeys tagged in the event.

These restrictions apply to `REQ`/`COUNT`/`NEG-OPEN`.