### PR TITLE
Allow gift wrap recipients to delete via NIP-09 (NIP-59)

### DIFF
--- a/src/apps/relay/RelayWebsocket.cpp
+++ b/src/apps/relay/RelayWebsocket.cpp
@@ -58,7 +58,7 @@ void RelayServer::runWebsocket(ThreadPool<MsgWebsocket>::Thread &thr) {
 
 
     auto supportedNips = []{
-        tao::json::value output = tao::json::value::array({ 1, 2, 4, 9, 11, 28, 40, 70 });
+        tao::json::value output = tao::json::value::array({ 1, 2, 4, 9, 11, 28, 40, 59, 70 });
 
         if (cfg().relay__auth__enabled && cfg().relay__auth__serviceUrl.size() > 0) output.push_back(42);
         if (cfg().relay__maxFilterLimitCount > 0) output.push_back(45);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -276,6 +276,23 @@ void writeEvents(lmdb::txn &txn, NegentropyFilterCache &neFilterCache, std::vect
                 continue;
             }
 
+            // NIP-59: a gift wrap is signed by a random key, so its recipient (p-tag) may have
+            // deleted it via NIP-09. Block re-publication if such a deletion is on record.
+            if (packed.kind() == 1059 || packed.kind() == 21059) {
+                bool recipientDeleted = false;
+                packed.foreachTag([&](char tagName, std::string_view tagVal){
+                    if (tagName == 'p' && env.lookup_Event__deletion(txn, std::string(packed.id()) + std::string(tagVal))) {
+                        recipientDeleted = true;
+                        return false;
+                    }
+                    return true;
+                });
+                if (recipientDeleted) {
+                    ev.status = EventWriteStatus::Deleted;
+                    continue;
+                }
+            }
+
             if (isReplaceableKind(packed.kind()) || isParamReplaceableKind(packed.kind())) {
                 std::optional<std::string> replace;
 
@@ -332,9 +349,27 @@ void writeEvents(lmdb::txn &txn, NegentropyFilterCache &neFilterCache, std::vect
                 packed.foreachTag([&](char tagName, std::string_view tagVal){
                     if (tagName == 'e') {
                         auto otherEv = lookupEventById(txn, tagVal);
-                        if (otherEv && PackedEventView(otherEv->buf).pubkey() == packed.pubkey()) {
-                            if (logDeletions) LI << "Deleting event (kind 5, e-tag). id=" << to_hex(tagVal);
-                            levIdsToDelete.push_back(otherEv->primaryKeyId);
+                        if (otherEv) {
+                            auto otherPacked = PackedEventView(otherEv->buf);
+                            bool canDelete = otherPacked.pubkey() == packed.pubkey();
+
+                            // NIP-59: gift wraps (kind 1059/21059) are signed by a random one-time-use
+                            // key, so the recipient is never the author. Per NIP-59, relays SHOULD delete
+                            // such events whose p-tag matches the signer of a NIP-09 deletion.
+                            if (!canDelete && (otherPacked.kind() == 1059 || otherPacked.kind() == 21059)) {
+                                otherPacked.foreachTag([&](char otherTagName, std::string_view otherTagVal){
+                                    if (otherTagName == 'p' && otherTagVal == packed.pubkey()) {
+                                        canDelete = true;
+                                        return false;
+                                    }
+                                    return true;
+                                });
+                            }
+
+                            if (canDelete) {
+                                if (logDeletions) LI << "Deleting event (kind 5, e-tag). id=" << to_hex(tagVal);
+                                levIdsToDelete.push_back(otherEv->primaryKeyId);
+                            }
                         }
                     } else if (tagName == 'a') {
                         try { // parsing a-tag can fail

--- a/test/writeTest.js
+++ b/test/writeTest.js
@@ -12,6 +12,10 @@ let ids = [
     sec: "a0b459d9ff90e30dc9d1749b34c4401dfe80ac2617c7732925ff994e8d5203ff",
     pub: "cc49e2a58373abc226eee84bee9ba954615aa2ef1563c4f955a74c4606a3b1fa",
   },
+  {
+    sec: "3bf1d347477a4f8d2e6a3b1c9d5e7f0a2b4c6d8e0f1a3b5c7d9e1f2a4b6c8d0e",
+    pub: "e83f7c58291be6a4d05c13f78a2e94b61d37c085f4a2960db51c8ef73a41d9f2",
+  },
 ];
 
 function addEvent(evInput) {
@@ -49,8 +53,8 @@ function doTest(spec) {
   const eventIds = [];
 
   for (const ev of spec.events) {
-    ev.pub = ev.from === 1 ? ids[1].pub : ids[0].pub;
-    ev.sec = ev.from === 1 ? ids[1].sec : ids[0].sec;
+    ev.pub = ids[ev.from || 0].pub;
+    ev.sec = ids[ev.from || 0].sec;
 
     // deep clone
     const e = JSON.parse(JSON.stringify(ev));
@@ -108,6 +112,7 @@ function doTest(spec) {
 const d = (v) => ["d", v];
 const e = (v) => ["e", v];
 const a = (v) => ["a", v];
+const p = (v) => ["p", v];
 
 doTest({
   desc: "Basic insert",
@@ -542,6 +547,94 @@ doTest({
       content: "hi",
       kind: 30003,
       created_at: 5000,
+    },
+  ],
+  verify: [1],
+});
+
+// ---- NIP-59 GIFT WRAP TESTS ----
+
+doTest({
+  desc: "Gift wrap recipient can delete",
+  events: [
+    {
+      content: "wrapped",
+      kind: 1059,
+      created_at: 5000,
+      tags: [p(ids[1].pub)],
+    },
+    {
+      from: 1,
+      content: "",
+      kind: 5,
+      created_at: 6000,
+      tags: [e("EV_0")],
+    },
+  ],
+  verify: [1],
+});
+
+doTest({
+  desc: "Gift wrap deletion prevents re-add",
+  events: [
+    {
+      content: "wrapped",
+      kind: 1059,
+      created_at: 5000,
+      tags: [p(ids[1].pub)],
+    },
+    {
+      from: 1,
+      content: "",
+      kind: 5,
+      created_at: 6000,
+      tags: [e("EV_0")],
+    },
+    {
+      content: "wrapped",
+      kind: 1059,
+      created_at: 5000,
+      tags: [p(ids[1].pub)],
+    },
+  ],
+  verify: [1],
+});
+
+doTest({
+  desc: "Non-recipient can't delete gift wrap",
+  events: [
+    {
+      content: "wrapped",
+      kind: 1059,
+      created_at: 5000,
+      tags: [p(ids[1].pub)],
+    },
+    {
+      from: 2,
+      content: "",
+      kind: 5,
+      created_at: 6000,
+      tags: [e("EV_0")],
+    },
+  ],
+  verify: [0, 1],
+});
+
+doTest({
+  desc: "Ephemeral gift wrap (21059) recipient can delete",
+  events: [
+    {
+      content: "wrapped",
+      kind: 21059,
+      created_at: 5000,
+      tags: [p(ids[1].pub)],
+    },
+    {
+      from: 1,
+      content: "",
+      kind: 5,
+      created_at: 6000,
+      tags: [e("EV_0")],
     },
   ],
   verify: [1],


### PR DESCRIPTION
Gift wraps (kind 1059/21059) are signed by a random one-time-use key, so the recipient is never the author and could not delete them with a standard kind 5 deletion. Per NIP-59, relays SHOULD delete such events whose p-tag matches the signer of a NIP-09 deletion.

- Permit kind 5 e-tag deletion of a gift wrap when the deletion pubkey matches the gift wrap's p-tag (recipient).
- Block re-publication of a gift wrap that the recipient has deleted by checking the deletion index against its p-tag on ingest.