### PR TITLE
Fix WSConnection reconnect stall: don't block the event loop during the reconnect delay

### DIFF
--- a/src/WSConnection.h
+++ b/src/WSConnection.h
@@ -64,14 +64,42 @@ class WSConnection : NonCopyable {
         if (hubTrigger) hubTrigger->send();
     }
 
+    // Perform the actual connection attempt. Must run on the websocket (hub) thread.
+    void connectNow() {
+        if (shutdown) return;
+        LI << "Attempting to connect to " << url;
+        hub.connect(url, nullptr, {}, 5000, hubGroup);
+    }
+
+    // Schedule a reconnect after `delay` ms WITHOUT blocking the event loop.
+    // Previously doConnect() did std::this_thread::sleep_for(delay), which blocks the
+    // hub thread that also runs the uv loop. That stalls the loop's cached clock by
+    // `delay` ms; the subsequent hub.connect() then arms its connection-timeout timer
+    // against the stale clock, so the timer is already expired and fires immediately on
+    // the next loop tick, tearing the freshly-connected socket down before the WS
+    // handshake completes. The very first connect used doConnect(0) (no sleep) so it
+    // worked, but every reconnect after a disconnect wedged permanently (the process
+    // keeps retrying and failing forever, never exiting, so a supervisor never restarts
+    // it). Deferring via a non-blocking uS::Timer keeps the loop clock accurate.
+    void scheduleReconnect(uint64_t delay) {
+        if (shutdown) return;
+        uS::Timer *timer = new uS::Timer(hub.getLoop());
+        timer->setData(this);
+        timer->start([](uS::Timer *t){
+            WSConnection *self = (WSConnection *) t->getData();
+            t->stop();
+            t->close();
+            self->connectNow();
+        }, delay, 0);
+    }
+
     void run() {
         hubGroup = hub.createGroup<uWS::CLIENT>(uWS::PERMESSAGE_DEFLATE | uWS::SLIDING_DEFLATE_WINDOW);
 
         auto doConnect = [&](uint64_t delay = 0){
-            if (delay) std::this_thread::sleep_for(std::chrono::milliseconds(delay));
             if (shutdown) return;
-            LI << "Attempting to connect to " << url;
-            hub.connect(url, nullptr, {}, 5000, hubGroup);
+            if (delay) scheduleReconnect(delay);
+            else connectNow();
         };
 
 

--- a/src/WSConnection.h
+++ b/src/WSConnection.h
@@ -14,6 +14,7 @@ class WSConnection : NonCopyable {
     uS::Async *hubTrigger = nullptr;
 
     uWS::WebSocket<uWS::CLIENT> *currWs = nullptr;
+    uS::Timer *reconnectTimer = nullptr; // pending non-blocking reconnect scheduled by scheduleReconnect()
 
 
   public:
@@ -38,7 +39,7 @@ class WSConnection : NonCopyable {
     std::string remoteAddr;
 
     ~WSConnection() {
-        if (hubGroup || hubTrigger || currWs) LW << "WSConnection destroyed before close";
+        if (hubGroup || hubTrigger || currWs || reconnectTimer) LW << "WSConnection destroyed before close";
     }
 
     void close() {
@@ -83,10 +84,12 @@ class WSConnection : NonCopyable {
     // it). Deferring via a non-blocking uS::Timer keeps the loop clock accurate.
     void scheduleReconnect(uint64_t delay) {
         if (shutdown) return;
-        uS::Timer *timer = new uS::Timer(hub.getLoop());
-        timer->setData(this);
-        timer->start([](uS::Timer *t){
+        if (reconnectTimer) return; // a reconnect is already pending; don't stack another timer
+        reconnectTimer = new uS::Timer(hub.getLoop());
+        reconnectTimer->setData(this);
+        reconnectTimer->start([](uS::Timer *t){
             WSConnection *self = (WSConnection *) t->getData();
+            self->reconnectTimer = nullptr;
             t->stop();
             t->close();
             self->connectNow();
@@ -218,6 +221,12 @@ class WSConnection : NonCopyable {
         if (currWs) {
             currWs->terminate();
             currWs = nullptr;
+        }
+
+        if (reconnectTimer) {
+            reconnectTimer->stop();
+            reconnectTimer->close();
+            reconnectTimer = nullptr;
         }
     }
 };


### PR DESCRIPTION
## Summary

`strfry stream` and `strfry sync` — the clients built on `WSConnection` — cannot reconnect after their first disconnect. The client keeps retrying and failing forever (`Attempting to connect` → `Websocket connection error` every 5s) even when the remote is perfectly reachable, and never recovers without a process restart. Since the process never exits, a supervisor (systemd/launchd `Restart=`) never restarts it — so a brief blip becomes an indefinite stall. (`strfry router` is not affected: it has its own cron-scheduled reconnect that does not block the loop.)

## Root cause

`WSConnection::doConnect()` implemented the reconnect delay with `std::this_thread::sleep_for()`:

```cpp
auto doConnect = [&](uint64_t delay = 0){
    if (delay) std::this_thread::sleep_for(std::chrono::milliseconds(delay));
    if (shutdown) return;
    LI << "Attempting to connect to " << url;
    hub.connect(url, nullptr, {}, 5000, hubGroup);
};
```

That thread also runs the uWS/uv event loop, so the sleep blocks the loop and stalls its cached clock by `delay` ms (default 5000). The following `hub.connect(..., 5000, ...)` arms a 5000 ms connection-timeout timer whose deadline is computed against the now-stale clock — already expired in real time — so it fires on the very next loop tick and `onEnd`s the freshly-TCP-connected socket before the WebSocket handshake completes.

The first connection uses `doConnect(0)` (no sleep → fresh clock) so it works; every reconnect (`doConnect(reconnectDelayMilliseconds)`) wedges.

## Fix

Defer the reconnect with a non-blocking `uS::Timer` on the hub's event loop instead of sleeping the loop thread, so the loop clock stays accurate and the connection-timeout behaves as intended.

The same *principle* is why `cmd_router.cpp` doesn't have this bug: it never sleeps the loop thread — its reconnect delay comes from a separate cron timer that just posts an event to the loop (via `hubTrigger`), and the actual `hub.connect()` runs on the loop thread. This patch doesn't copy the router's cron/inbox machinery; a one-shot `uS::Timer` on the loop is enough for `WSConnection`.

## Reproduce (deterministic)

1. Start a throwaway relay and a stream client pointed at it:
   ```
   ./strfry --config relay.conf relay                       # e.g. bind 127.0.0.1:7777
   ./strfry --config client.conf stream ws://127.0.0.1:7777 --dir down
   ```
   → the client logs `Connected`.
2. Stop the relay (the client enters the reconnect loop), wait a few seconds, then start the relay again.
3. **Before this patch:** the client loops `Attempting to connect` / `Websocket connection error` every 5s forever and never reconnects, even though the relay is back and a freshly-started client connects to it instantly.
   **After this patch:** the client reconnects on its next attempt.

## Extra confirmation

Lowering `reconnectDelayMilliseconds` below the 5000 ms connection-timeout (e.g. 250) also makes reconnect succeed with the old code — confirming the delay-vs-timeout clock interaction is the cause.
