### PR TITLE
Lookup event in the index instead of using eventPayload for creating PackedEvent

### DIFF
--- a/src/apps/relay/RelayReqWorker.cpp
+++ b/src/apps/relay/RelayReqWorker.cpp
@@ -11,8 +11,10 @@ void RelayServer::runReqWorker(ThreadPool<MsgReqWorker>::Thread &thr) {
     queries.onEvent = [&](lmdb::txn &txn, const auto &sub, uint64_t levId, std::string_view eventPayload){
         if (sub.countOnly) return;
         auto it = connIdToAuthedPubkey.find(sub.connId);
+        auto ev = lookupEventByLevId(txn, levId);
+        PackedEventView packed(ev.buf);
         Bytes32 subscriberAuthedPubkey = it == connIdToAuthedPubkey.end() ? Bytes32() : it->second;
-        if (!ReadRestrictor::shouldSendToSubscriber(PackedEventView(eventPayload), subscriberAuthedPubkey)) {
+        if (!ReadRestrictor::shouldSendToSubscriber(packed, subscriberAuthedPubkey)) {
             return; 
         }
         

--- a/strfry.conf
+++ b/strfry.conf
@@ -62,7 +62,7 @@ relay {
         # Comma-separated list of kinds that require NIP-42 AUTH to read via
         # REQ/COUNT/NEG-OPEN. A filter with no "kinds" field is treated as
         # restricted. Example for DMs: "4,1059".
-        restrictedReadKinds = ""
+        restrictedReadKinds = "4,1059"
 
         # When a filter matches restrictedReadKinds, also require the authed
         # pubkey to appear in its "authors" or "#p" set.


### PR DESCRIPTION
fixes #256 

also adds kinds 4 and 1059 as the default for `restrictedReadKinds`.