### PR TITLE
feat: Windows compatibility support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.d
 *.o
 /strfry
+/strfry.exe
 /strfry-db/*.mdb
 .vscode/*
 /strfry-db-test*

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,20 @@ export XLDFLAGS  += $(BREW_LIBS)
 endif
 INCS += -Iexternal/negentropy/cpp
 
-build/StrfryTemplates.h: $(shell find src/tmpls/ -type f -name '*.tmpl')
-	PERL5LIB=golpe/vendor/ perl golpe/external/templar/templar.pl src/tmpls/ strfrytmpl $@
+build/StrfryTemplates.h: $(wildcard src/tmpls/*.tmpl)
+	perl -Igolpe/vendor golpe/external/templar/templar.pl src/tmpls/ strfrytmpl $@
 
 src/apps/relay/RelayWebsocket.o: build/StrfryTemplates.h
 
-.PHONY: test-subid
-test-subid: build/subid_tests
-	build/subid_tests
+ifeq ($(OS),Windows_NT)
+    TEST_BIN = build/subid_tests.exe
+else
+    TEST_BIN = build/subid_tests
+endif
 
-build/subid_tests: test/tests/SubIdTests.cpp build/golpe.h
+.PHONY: test-subid
+test-subid: $(TEST_BIN)
+	$(TEST_BIN)
+
+$(TEST_BIN): test/tests/SubIdTests.cpp build/golpe.h
 	$(CXX) $(CXXFLAGS) $(INCS) $< -o $@

--- a/src/PluginEventSifter.h
+++ b/src/PluginEventSifter.h
@@ -2,6 +2,7 @@
 
 #include <string.h>
 #include <errno.h>
+#ifndef _WIN32
 #include <spawn.h>
 #include <unistd.h>
 #include <sys/types.h>
@@ -9,24 +10,31 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <signal.h>
+#endif
 
 #include <memory>
 
+#ifndef _WIN32
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 #define st_mtim st_mtimespec
 #endif
+#endif
 
+#ifndef _WIN32
 #include "hoytech/stream.h"
+#endif
 
 #include "golpe.h"
 
 #include "events.h"
 
+#ifndef _WIN32
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
 extern char **environ;
 #elif defined(__APPLE__)
 #include <crt_externs.h>
 #define environ (*_NSGetEnviron())
+#endif
 #endif
 
 
@@ -37,6 +45,26 @@ enum class PluginEventSifterResult {
     ShadowReject,
 };
 
+
+#ifdef _WIN32
+
+struct PluginEventSifter {
+    PluginEventSifterResult acceptEvent(const std::string &pluginCmd, const tao::json::value &evJson, EventSourceType sourceType, std::string_view sourceInfo, const Bytes32 &authed, std::string &okMsg) {
+        if (pluginCmd.size() == 0) {
+            return PluginEventSifterResult::Accept;
+        }
+
+        static bool warned = false;
+        if (!warned) {
+            LW << "Write policy plugins are not supported on Windows. All events are accepted by default.";
+            warned = true;
+        }
+
+        return PluginEventSifterResult::Accept;
+    }
+};
+
+#else
 
 struct PluginEventSifter {
     struct RunningPlugin {
@@ -198,3 +226,5 @@ struct PluginEventSifter {
         running = make_unique<RunningPlugin>(pid, inPipe.extractFd(0), outPipe.extractFd(1), pluginCmd);
     }
 };
+
+#endif

--- a/src/apps/dbutils/cmd_import.cpp
+++ b/src/apps/dbutils/cmd_import.cpp
@@ -5,8 +5,10 @@
 
 #include <docopt.h>
 #include "golpe.h"
+#include "win32.h"
 
 #include "WriterPipeline.h"
+
 
 
 static const char USAGE[] =

--- a/src/apps/mesh/cmd_upload.cpp
+++ b/src/apps/mesh/cmd_upload.cpp
@@ -4,6 +4,8 @@
 #include <hoytech/file_change_monitor.h>
 
 #include "golpe.h"
+#include "win32.h"
+
 
 #include "WSConnection.h"
 

--- a/src/apps/relay/RelaySignalHandler.cpp
+++ b/src/apps/relay/RelaySignalHandler.cpp
@@ -1,4 +1,6 @@
+#ifndef _WIN32
 #include <signal.h>
+#endif
 
 #include "RelayServer.h"
 
@@ -6,6 +8,7 @@
 void RelayServer::runSignalHandler() {
     setThreadName("signalHandler");
 
+#ifndef _WIN32
     sigset_t sigset;
     sigemptyset(&sigset);
     sigaddset(&sigset, SIGUSR1);
@@ -22,4 +25,9 @@ void RelayServer::runSignalHandler() {
             LW << "Got unexpected signal: " << sig;
         }
     }
+#else
+    while (1) {
+        std::this_thread::sleep_for(std::chrono::seconds(1000));
+    }
+#endif
 }

--- a/src/apps/relay/cmd_relay.cpp
+++ b/src/apps/relay/cmd_relay.cpp
@@ -1,5 +1,7 @@
+#ifndef _WIN32
 #include <pthread.h>
 #include <signal.h>
+#endif
 
 #include <docopt.h>
 
@@ -40,6 +42,7 @@ void cmd_relay(const std::vector<std::string> &subArgs) {
 }
 
 void RelayServer::run() {
+#ifndef _WIN32
     {
         sigset_t set;
         sigemptyset(&set);
@@ -47,6 +50,7 @@ void RelayServer::run() {
         int s = pthread_sigmask(SIG_BLOCK, &set, NULL);
         if (s != 0) throw herr("Unable to set sigmask: ", strerror(errno));
     }
+#endif
 
     tpWebsocket.init("Websocket", 1, [this](auto &thr){
         runWebsocket(thr);

--- a/src/misc.cpp
+++ b/src/misc.cpp
@@ -1,10 +1,5 @@
-#include <arpa/inet.h>
-#ifdef __FreeBSD__
-#include <sys/socket.h>
-#include <netinet/in.h>
-#endif
+#include "win32.h"
 #include <stdio.h>
-#include <signal.h>
 
 #include <algorithm>
 #include <string>
@@ -121,10 +116,12 @@ uint64_t getDBVersion(lmdb::txn &txn) {
 
 
 void exitOnSigPipe() {
+#ifndef _WIN32
     struct sigaction act;
     memset(&act, 0, sizeof act);
     act.sa_sigaction = [](int, siginfo_t*, void*){ ::exit(1); };
     if (sigaction(SIGPIPE, &act, nullptr)) throw herr("couldn't run sigaction(): ", strerror(errno));
+#endif
 }
 
 

--- a/src/onAppStartup.cpp
+++ b/src/onAppStartup.cpp
@@ -1,8 +1,10 @@
+#include "win32.h"
+#ifndef _WIN32
 #include <sys/time.h>
 #include <sys/resource.h>
+#endif
 #include <string.h>
 #include <errno.h>
-#include <unistd.h>
 
 #include <iostream>
 
@@ -16,6 +18,8 @@
 
 
 void onPreStartup(int argc, char **argv) {
+    win32_init_sockets();
+#ifndef _WIN32
     if (getuid() == 0) {
         if (isatty(fileno(stderr))) {
             std::cerr << "\x1b[1;35mWARNING: Running as root is not recommended\x1b[0m" << std::endl;
@@ -23,6 +27,7 @@ void onPreStartup(int argc, char **argv) {
             std::cerr << "WARNING: Running as root is not recommended" << std::endl;
         }
     }
+#endif
 
     if (argc > 1) return;
 
@@ -78,6 +83,7 @@ static void dbCheck(lmdb::txn &txn, const std::string &cmd) {
 }
 
 static void setRLimits() {
+#ifndef _WIN32
     if (!cfg().relay__nofiles) return;
     struct rlimit curr;
 
@@ -101,6 +107,7 @@ static void setRLimits() {
 #endif
 
     if (setrlimit(RLIMIT_NOFILE, &curr)) throw herr("Failed setting NOFILES limit to ", cfg().relay__nofiles, ": ", strerror(errno));
+#endif
 }
 
 

--- a/src/win32.h
+++ b/src/win32.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#ifdef _WIN32
+
+#include <ws2tcpip.h>
+#include <io.h>
+#include <direct.h>
+
+#define isatty _isatty
+#define fileno _fileno
+#define unlink _unlink
+#define chmod _chmod
+
+inline ssize_t getline(char **lineptr, size_t *n, FILE *stream) {
+    if (lineptr == NULL || n == NULL || stream == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (*lineptr == NULL || *n == 0) {
+        *n = 128;
+        *lineptr = (char *)malloc(*n);
+        if (*lineptr == NULL) {
+            errno = ENOMEM;
+            return -1;
+        }
+    }
+    size_t count = 0;
+    int c;
+    while ((c = fgetc(stream)) != EOF) {
+        if (count + 1 >= *n) {
+            size_t new_len = *n * 2;
+            char *new_ptr = (char *)realloc(*lineptr, new_len);
+            if (new_ptr == NULL) {
+                errno = ENOMEM;
+                return -1;
+            }
+            *lineptr = new_ptr;
+            *n = new_len;
+        }
+        (*lineptr)[count++] = (char)c;
+        if (c == '\n') {
+            break;
+        }
+    }
+    if (count == 0 && c == EOF) {
+        return -1;
+    }
+    (*lineptr)[count] = '\0';
+    return (ssize_t)count;
+}
+
+inline void win32_init_sockets() {
+    WSADATA wsaData;
+    int res = WSAStartup(MAKEWORD(2, 2), &wsaData);
+    if (res != 0) {
+        fprintf(stderr, "WSAStartup failed: %d\n", res);
+        exit(1);
+    }
+}
+
+#else
+
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <signal.h>
+
+inline void win32_init_sockets() {}
+
+#endif

--- a/strfry.conf
+++ b/strfry.conf
@@ -10,7 +10,7 @@ dbParams {
     maxreaders = 256
 
     # Size of mmap() to use when loading LMDB (default is 10TB, does *not* correspond to disk-space used) (restart required)
-    mapsize = 10995116277760
+    mapsize = 10737418240
 
     # Disables read-ahead when accessing the LMDB mapping. Reduces IO activity when DB size is larger than RAM. (restart required)
     noReadAhead = false


### PR DESCRIPTION
## Description

strfry currently only builds on Unix-like systems. This PR makes it build and run on Windows by introducing polyfills, adjusting build configurations, and bypassing Linux-specific APIs.

## Update

- **Build System**: Adjusted `Makefile` to handle `.exe` extensions and use cross-platform `perl -I` flags.
- **Polyfills & Stubs**: Added `#ifdef _WIN32` guards around POSIX-only APIs (like `rlimit`, `syslog`, and POSIX signal handlers) and introduced a `getline()` polyfill in `cmd_import.cpp` and `cmd_upload.cpp`.
- **Network Initialization**: Integrated `WSAStartup` in `onAppStartup.cpp` to properly initialize Winsock.
- **LMDB Mapsize**: Reduced the default LMDB `mapsize` in `strfry.conf` to 10GB, as Windows enforces stricter memory mapping limits compared to Linux.

## Issue

- fixes Portability: Windows compatibility

## Depends On

- hoytech/golpe#7
- After the golpe PR gets merged and the submodule gets bumped in strfry, it will be fully ready to get merged.

## Testing

<img width="424" height="247" alt="{428D3A02-1A56-40BB-B2DD-C2F7835F77E9}" src="https://github.com/user-attachments/assets/cc109a51-a52a-4e30-a0d4-b2c4ec0d0219" />
<img width="665" height="131" alt="{213292EB-8C0A-447E-92F4-37C80C0663FB}" src="https://github.com/user-attachments/assets/374d0ece-3871-4abf-8716-318d0d575bff" />

- Compiled and successfully executed `strfry.exe` on Windows 11 (x64).